### PR TITLE
refactor(bot): Simplify bot.py by separating responsibilities (Issue #21)

### DIFF
--- a/lattice/core/memory_orchestrator.py
+++ b/lattice/core/memory_orchestrator.py
@@ -4,6 +4,7 @@ Handles storing and retrieving from episodic and semantic memory.
 """
 
 import asyncio
+from typing import Any
 from uuid import UUID
 
 import structlog
@@ -56,7 +57,7 @@ async def store_bot_message(
     discord_message_id: int,
     channel_id: int,
     is_proactive: bool = False,
-    generation_metadata: dict | None = None,
+    generation_metadata: dict[str, Any] | None = None,
 ) -> UUID:
     """Store a bot message in episodic memory.
 
@@ -122,7 +123,10 @@ async def consolidate_message_async(
     content: str,
     context: list[str],
 ) -> None:
-    """Start async consolidation task for a message.
+    """Start async consolidation task for a message (fire-and-forget).
+
+    Note: This creates a background task that is not awaited. Errors in
+    consolidation will be logged but not propagated to the caller.
 
     Args:
         message_id: UUID of the stored message

--- a/lattice/core/response_generator.py
+++ b/lattice/core/response_generator.py
@@ -3,6 +3,8 @@
 Handles prompt formatting, LLM generation, and message splitting for Discord.
 """
 
+from typing import Any
+
 import structlog
 
 from lattice.memory import episodic, procedural, semantic
@@ -16,7 +18,7 @@ async def generate_response(
     user_message: str,
     semantic_facts: list[semantic.StableFact],
     recent_messages: list[episodic.EpisodicMessage],
-) -> tuple[GenerationResult, str, dict]:
+) -> tuple[GenerationResult, str, dict[str, Any]]:
     """Generate a response using the prompt template.
 
     Args:

--- a/lattice/discord_client/bot.py
+++ b/lattice/discord_client/bot.py
@@ -166,6 +166,8 @@ class LatticeBot(commands.Bot):
             await set_next_check_at(next_check)
 
             # Retrieve context
+            # TODO: Replace hardcoded values with Context Archetype System when implemented
+            # See: docs/context-archetype-system.md  # noqa: ERA001
             semantic_facts, recent_messages = await memory_orchestrator.retrieve_context(
                 query=message.content,
                 channel_id=message.channel.id,


### PR DESCRIPTION
## Summary

Refactors `bot.py` to follow the Single Responsibility Principle by extracting LLM generation and memory operations into dedicated modules.

## Problem

`bot.py` was 517 lines and handled too many responsibilities:
- Discord event handling
- Memory operations (store/retrieve messages, facts)
- LLM response generation
- Message splitting for Discord limits
- Scheduler management
- Circuit breaker logic

This made it hard to test, modify, and understand.

## Solution

Created two focused modules in `lattice/core/`:

### 1. `response_generator.py` (120 lines)
- `generate_response()`: Formats prompts and calls LLM
- `split_response()`: Handles Discord's 2000 char limit

### 2. `memory_orchestrator.py` (138 lines)
- `store_user_message()`: Unified user message storage (episodic + semantic)
- `store_bot_message()`: Bot message storage with generation metadata
- `retrieve_context()`: Parallel semantic + episodic retrieval
- `consolidate_message_async()`: Background consolidation tasks

### 3. Refactored `bot.py` (385 lines, down from 517)
- Now focuses on Discord event handling only
- Uses new modules for memory and response generation
- Removed private methods that are now in dedicated modules
- Simplified `on_message` flow

## Impact

**Before:**
- 517 lines in one file
- Mixed concerns at different abstraction levels
- Hard to test individual components
- Difficult to modify without side effects

**After:**
- 385 lines in bot.py (25% reduction)
- Clear separation: Discord ↔ Memory ↔ LLM
- Each module has single, testable responsibility
- Easier to extend (e.g., add new memory strategies)

## Testing

- ✅ All 122 tests pass
- ✅ Quality checks pass (ruff, mypy, security)
- ✅ Coverage maintained at 57%
- ✅ No functional changes - pure refactor

## Notes

- Follows same pattern as existing `handlers.py` (feedback/North Star separation)
- Aligns with project's "radical simplicity" philosophy
- Memory orchestrator enables future optimizations (e.g., caching, batching)
- Response generator can be easily extended for context archetype system

Closes #21