### PR TITLE
fix(ops): expose port 8080 in docker-compose for health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
       # Persist logs
       - ./logs:/app/logs
     restart: unless-stopped
+    ports:
+      - "8080:8080"
     # Resource limits matching target environment (2GB RAM / 1vCPU)
     deploy:
       resources:


### PR DESCRIPTION
Exposes port 8080 in the docker-compose.yml file to allow the health check to pass during deployment.