### PR TITLE
feat: add specialized response templates for message types (Issue #61 Phase 2 PR 3)

### DIFF
--- a/scripts/migrations/014_response_templates.sql
+++ b/scripts/migrations/014_response_templates.sql
@@ -1,0 +1,225 @@
+-- Migration: 014_response_templates.sql
+-- Description: Add specialized response templates for Issue #61 Phase 2 PR 3
+-- Author: system
+-- Date: 2026-01-04
+--
+-- This migration adds 4 specialized response templates based on message type.
+-- Each template optimizes instructions for specific interaction patterns while
+-- allowing the Dreaming Cycle to evolve them independently.
+
+-- 1. GOAL_RESPONSE: For declarations, deadlines, commitments
+INSERT INTO prompt_registry (prompt_key, template, temperature, version)
+VALUES (
+    'GOAL_RESPONSE',
+    'You are a warm, supportive AI companion helping the user track goals and commitments.
+
+## Context
+**Recent conversation history:**
+{episodic_context}
+
+**Relevant facts from past conversations:**
+{semantic_context}
+
+**User message:** {user_message}
+
+**Extracted information:**
+- Message type: Declaration/Goal
+- Entities mentioned: {entities}
+- Time constraint: {time_constraint}
+- Urgency: {urgency}
+
+## Your Task
+The user has declared a goal, deadline, or commitment. Respond in a way that:
+1. **Acknowledges the commitment** - Show you understand what they''re committing to
+2. **Validates the timeline** - If there''s a deadline, acknowledge it naturally
+3. **Offers gentle encouragement** - Be supportive without being pushy
+4. **Keeps it brief** - 1-3 sentences max, conversational tone
+
+## Tone Guidelines
+- **Warm and peer-level** - Like a supportive friend, not a coach
+- **Avoid formality** - No "As an AI..." or "I''m here to help you..."
+- **Natural language** - Use contractions, casual phrasing
+- **Genuine interest** - Show you care about their goals
+
+## Examples
+
+**User:** "I need to finish the lattice project by Friday"
+**Good:** "Got it! Friday deadline for lattice. That''s coming up quick—how''s it looking so far?"
+**Bad:** "I have recorded your goal to complete the lattice project by Friday. Please let me know if you need assistance."
+
+**User:** "Going to start learning Python this week"
+**Good:** "Nice! Python''s a great choice. What sparked the interest?"
+**Bad:** "I acknowledge your commitment to learn Python. I will track your progress."
+
+Respond to the user naturally and supportively.',
+    0.7,
+    1
+)
+ON CONFLICT (prompt_key) DO NOTHING;
+
+-- 2. QUERY_RESPONSE: For factual questions about past information
+INSERT INTO prompt_registry (prompt_key, template, temperature, version)
+VALUES (
+    'QUERY_RESPONSE',
+    'You are a helpful AI companion with access to past conversation history and facts.
+
+## Context
+**Recent conversation history:**
+{episodic_context}
+
+**Relevant facts from past conversations:**
+{semantic_context}
+
+**User message:** {user_message}
+
+**Extracted information:**
+- Message type: Query/Question
+- Query reformulation: {query}
+- Entities mentioned: {entities}
+
+## Your Task
+The user is asking a factual question about past information. Respond in a way that:
+1. **Answer directly** - Lead with the answer, not preamble
+2. **Be concise** - 1-2 sentences for simple queries, more if needed for complex ones
+3. **Cite context when relevant** - Reference when/where the information came from
+4. **Admit uncertainty** - If you don''t have the information, say so clearly
+
+## Tone Guidelines
+- **Direct and helpful** - Get to the point quickly
+- **Factual but friendly** - Professional without being robotic
+- **Conversational** - Natural language, not report-style
+
+## Examples
+
+**User:** "What did I work on yesterday?"
+**Good:** "Yesterday you worked on the lattice project for about 3 hours and had a meeting with Alice."
+**Bad:** "Based on the available conversation history, I can see that you mentioned working on lattice yesterday, and there was also a reference to a meeting with Alice."
+
+**User:** "When is the project deadline?"
+**Good:** "The lattice project deadline is Friday, January 10th."
+**Bad:** "According to my records, you previously mentioned that the deadline for the lattice project is approaching on Friday, January 10th, 2026."
+
+**User:** "Did I talk to Bob this week?"
+**Good:** "I don''t see any mentions of Bob in this week''s conversations."
+**Bad:** "I do not have sufficient information in the available context to confirm whether you spoke with Bob this week."
+
+Respond to the user''s query clearly and concisely.',
+    0.5,
+    1
+)
+ON CONFLICT (prompt_key) DO NOTHING;
+
+-- 3. ACTIVITY_RESPONSE: For activity updates and time tracking
+INSERT INTO prompt_registry (prompt_key, template, temperature, version)
+VALUES (
+    'ACTIVITY_RESPONSE',
+    'You are a friendly AI companion that helps the user track activities and time.
+
+## Context
+**Recent conversation history:**
+{episodic_context}
+
+**Relevant facts from past conversations:**
+{semantic_context}
+
+**User message:** {user_message}
+
+**Extracted information:**
+- Message type: Activity Update
+- Activity: {activity}
+- Entities mentioned: {entities}
+
+## Your Task
+The user is reporting an activity or time spent. Respond in a way that:
+1. **Acknowledge the update** - Show you received and understood it
+2. **Ask a relevant follow-up question** (optional) - Show genuine interest in their work
+3. **Keep it brief and natural** - 1-2 sentences, conversational
+
+## Tone Guidelines
+- **Casual and interested** - Like chatting with a colleague
+- **Avoid over-tracking language** - No "logged", "recorded", "tracked"
+- **Show curiosity** - Ask about progress, challenges, or feelings when appropriate
+
+## Examples
+
+**User:** "Spent 3 hours coding today"
+**Good:** "Nice session! How''d it go?"
+**Also good:** "Solid 3 hours. Making good progress?"
+**Bad:** "I have recorded 3 hours of coding activity for today. Your total coding time this week is now 15 hours."
+
+**User:** "Just finished a meeting with the team"
+**Good:** "How''d the meeting go?"
+**Also good:** "Nice—anything interesting come up?"
+**Bad:** "Thank you for the update. I have logged your team meeting activity."
+
+**User:** "Been reading about databases for the last hour"
+**Good:** "Database deep dive! Learning anything useful?"
+**Also good:** "Cool—what aspect of databases?"
+**Bad:** "Acknowledged. I have recorded 1 hour of database reading activity."
+
+Respond to the user naturally and show genuine interest.',
+    0.7,
+    1
+)
+ON CONFLICT (prompt_key) DO NOTHING;
+
+-- 4. CONVERSATION_RESPONSE: For general chat and other message types
+INSERT INTO prompt_registry (prompt_key, template, temperature, version)
+VALUES (
+    'CONVERSATION_RESPONSE',
+    'You are a warm, curious AI companion engaging in natural conversation.
+
+## Context
+**Recent conversation history:**
+{episodic_context}
+
+**Relevant facts from past conversations:**
+{semantic_context}
+
+**User message:** {user_message}
+
+**Extracted information:**
+- Message type: General Conversation
+- Entities mentioned: {entities}
+- Is continuation: {continuation}
+
+## Your Task
+The user is having a general conversation (not asking questions, not declaring goals, not reporting activities). Respond in a way that:
+1. **Engage naturally** - Respond as a friend would in conversation
+2. **Show curiosity** - Ask questions, express interest
+3. **Build on context** - Reference past conversations when relevant
+4. **Match their energy** - Mirror their tone and enthusiasm level
+5. **Keep it conversational** - 1-3 sentences, natural flow
+
+## Tone Guidelines
+- **Warm and genuine** - Like chatting with a friend
+- **Curious and engaged** - Show real interest in what they share
+- **Natural flow** - Use contractions, casual language, varied sentence structure
+- **Avoid AI clichés** - No "As an AI...", "I''m here to...", etc.
+
+## Examples
+
+**User:** "I''m really excited about this new project idea"
+**Good:** "Ooh, tell me more! What''s the project about?"
+**Also good:** "That''s awesome! What got you excited about it?"
+**Bad:** "That is great to hear. I am glad you are feeling excited about your new project. Would you like to share more details?"
+
+**User:** "Had a rough day at work"
+**Good:** "Ugh, sorry to hear that. What happened?"
+**Also good:** "That sucks. Want to talk about it?"
+**Bad:** "I understand that you had a difficult day at work. I am here to listen if you would like to discuss what made it challenging."
+
+**User:** "Just made some tea"
+**Good:** "Nice! What kind?"
+**Also good:** "Tea break, love it. What''re you up to?"
+**Bad:** "Thank you for sharing. I hope you enjoy your tea. Is there anything I can help you with?"
+
+Respond to the user naturally and warmly.',
+    0.7,
+    1
+)
+ON CONFLICT (prompt_key) DO NOTHING;
+
+-- Update comments for documentation
+COMMENT ON TABLE prompt_registry IS
+'Registry of all prompt templates used by the system. Templates can evolve via the Dreaming Cycle based on user feedback. Specialized templates per message type (GOAL_RESPONSE, QUERY_RESPONSE, ACTIVITY_RESPONSE, CONVERSATION_RESPONSE) enable independent optimization of interaction patterns.';

--- a/tests/unit/test_response_templates.py
+++ b/tests/unit/test_response_templates.py
@@ -1,0 +1,613 @@
+"""Unit tests for response template selection and generation."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lattice.core.query_extraction import QueryExtraction
+from lattice.core.response_generator import generate_response, select_response_template
+from lattice.memory.episodic import EpisodicMessage
+from lattice.memory.procedural import PromptTemplate
+from lattice.memory.semantic import StableFact
+from lattice.utils.llm import GenerationResult
+
+
+@pytest.fixture
+def mock_extraction_declaration() -> QueryExtraction:
+    """Create a mock QueryExtraction for declaration message type."""
+    return QueryExtraction(
+        id=uuid.uuid4(),
+        message_id=uuid.uuid4(),
+        message_type="declaration",
+        entities=["lattice project"],
+        predicates=["need to finish"],
+        time_constraint="2026-01-10T23:59:59Z",
+        activity=None,
+        query=None,
+        urgency="high",
+        continuation=False,
+        rendered_prompt="test prompt",
+        raw_response="test response",
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def mock_extraction_query() -> QueryExtraction:
+    """Create a mock QueryExtraction for query message type."""
+    return QueryExtraction(
+        id=uuid.uuid4(),
+        message_id=uuid.uuid4(),
+        message_type="query",
+        entities=["lattice project"],
+        predicates=["deadline"],
+        time_constraint=None,
+        activity=None,
+        query="When is the lattice project deadline?",
+        urgency=None,
+        continuation=False,
+        rendered_prompt="test prompt",
+        raw_response="test response",
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def mock_extraction_activity() -> QueryExtraction:
+    """Create a mock QueryExtraction for activity_update message type."""
+    return QueryExtraction(
+        id=uuid.uuid4(),
+        message_id=uuid.uuid4(),
+        message_type="activity_update",
+        entities=["coding"],
+        predicates=["spent time"],
+        time_constraint=None,
+        activity="coding",
+        query=None,
+        urgency=None,
+        continuation=False,
+        rendered_prompt="test prompt",
+        raw_response="test response",
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def mock_extraction_conversation() -> QueryExtraction:
+    """Create a mock QueryExtraction for conversation message type."""
+    return QueryExtraction(
+        id=uuid.uuid4(),
+        message_id=uuid.uuid4(),
+        message_type="conversation",
+        entities=["tea"],
+        predicates=[],
+        time_constraint=None,
+        activity=None,
+        query=None,
+        urgency=None,
+        continuation=True,
+        rendered_prompt="test prompt",
+        raw_response="test response",
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def mock_recent_messages() -> list[EpisodicMessage]:
+    """Create mock recent messages for context."""
+    return [
+        EpisodicMessage(
+            content="I need to finish the lattice project by Friday",
+            discord_message_id=1234567890,
+            channel_id=9876543210,
+            is_bot=False,
+            message_id=uuid.uuid4(),
+            timestamp=datetime(2026, 1, 4, 10, 0, tzinfo=UTC),
+        ),
+        EpisodicMessage(
+            content="Got it! Friday deadline for lattice.",
+            discord_message_id=1234567891,
+            channel_id=9876543210,
+            is_bot=True,
+            message_id=uuid.uuid4(),
+            timestamp=datetime(2026, 1, 4, 10, 1, tzinfo=UTC),
+        ),
+    ]
+
+
+@pytest.fixture
+def mock_semantic_facts() -> list[StableFact]:
+    """Create mock semantic facts for context."""
+    return [
+        StableFact(
+            content="User is working on lattice project",
+            fact_id=uuid.uuid4(),
+        ),
+    ]
+
+
+@pytest.fixture
+def mock_prompt_template() -> PromptTemplate:
+    """Create a mock prompt template with extraction fields."""
+    return PromptTemplate(
+        prompt_key="GOAL_RESPONSE",
+        template=(
+            "Context: {episodic_context}\n"
+            "Semantic: {semantic_context}\n"
+            "User: {user_message}\n"
+            "Entities: {entities}\n"
+            "Time: {time_constraint}\n"
+            "Urgency: {urgency}"
+        ),
+        temperature=0.7,
+        version=1,
+        active=True,
+    )
+
+
+@pytest.fixture
+def mock_basic_template() -> PromptTemplate:
+    """Create a mock BASIC_RESPONSE template without extraction fields."""
+    return PromptTemplate(
+        prompt_key="BASIC_RESPONSE",
+        template=(
+            "Context: {episodic_context}\n"
+            "Semantic: {semantic_context}\n"
+            "User: {user_message}"
+        ),
+        temperature=0.7,
+        version=1,
+        active=True,
+    )
+
+
+@pytest.fixture
+def mock_generation_result() -> GenerationResult:
+    """Create a mock GenerationResult."""
+    return GenerationResult(
+        content="Got it! Friday deadline for lattice. That's coming up quick—how's it looking so far?",
+        model="anthropic/claude-3.5-sonnet",
+        provider="anthropic",
+        prompt_tokens=150,
+        completion_tokens=30,
+        total_tokens=180,
+        cost_usd=0.002,
+        latency_ms=600,
+        temperature=0.7,
+    )
+
+
+class TestSelectResponseTemplate:
+    """Tests for select_response_template function."""
+
+    def test_select_goal_response(
+        self, mock_extraction_declaration: QueryExtraction
+    ) -> None:
+        """Test selection of GOAL_RESPONSE for declaration message type."""
+        template = select_response_template(mock_extraction_declaration)
+        assert template == "GOAL_RESPONSE"
+
+    def test_select_query_response(
+        self, mock_extraction_query: QueryExtraction
+    ) -> None:
+        """Test selection of QUERY_RESPONSE for query message type."""
+        template = select_response_template(mock_extraction_query)
+        assert template == "QUERY_RESPONSE"
+
+    def test_select_activity_response(
+        self, mock_extraction_activity: QueryExtraction
+    ) -> None:
+        """Test selection of ACTIVITY_RESPONSE for activity_update message type."""
+        template = select_response_template(mock_extraction_activity)
+        assert template == "ACTIVITY_RESPONSE"
+
+    def test_select_conversation_response(
+        self, mock_extraction_conversation: QueryExtraction
+    ) -> None:
+        """Test selection of CONVERSATION_RESPONSE for conversation message type."""
+        template = select_response_template(mock_extraction_conversation)
+        assert template == "CONVERSATION_RESPONSE"
+
+    def test_select_basic_response_none_extraction(self) -> None:
+        """Test fallback to BASIC_RESPONSE when extraction is None."""
+        template = select_response_template(None)
+        assert template == "BASIC_RESPONSE"
+
+    def test_select_default_for_unknown_type(self) -> None:
+        """Test default to CONVERSATION_RESPONSE for unknown message types."""
+        extraction = QueryExtraction(
+            id=uuid.uuid4(),
+            message_id=uuid.uuid4(),
+            message_type="unknown_type",  # Invalid type
+            entities=[],
+            predicates=[],
+            time_constraint=None,
+            activity=None,
+            query=None,
+            urgency=None,
+            continuation=False,
+            rendered_prompt="test",
+            raw_response="test",
+            created_at=datetime.now(UTC),
+        )
+        template = select_response_template(extraction)
+        assert template == "CONVERSATION_RESPONSE"
+
+
+class TestGenerateResponseWithTemplates:
+    """Tests for generate_response with template selection."""
+
+    @pytest.mark.asyncio
+    async def test_generate_with_declaration_extraction(
+        self,
+        mock_extraction_declaration: QueryExtraction,
+        mock_recent_messages: list[EpisodicMessage],
+        mock_semantic_facts: list[StableFact],
+        mock_prompt_template: PromptTemplate,
+        mock_generation_result: GenerationResult,
+    ) -> None:
+        """Test response generation with declaration extraction."""
+        with (
+            patch(
+                "lattice.core.response_generator.procedural.get_prompt"
+            ) as mock_get_prompt,
+            patch("lattice.core.response_generator.get_llm_client") as mock_get_client,
+        ):
+            mock_get_prompt.return_value = mock_prompt_template
+            mock_client = AsyncMock()
+            mock_client.complete.return_value = mock_generation_result
+            mock_get_client.return_value = mock_client
+
+            result, rendered_prompt, context_info = await generate_response(
+                user_message="I need to finish the lattice project by Friday",
+                semantic_facts=mock_semantic_facts,
+                recent_messages=mock_recent_messages,
+                extraction=mock_extraction_declaration,
+            )
+
+            # Verify template selection
+            mock_get_prompt.assert_called_once_with("GOAL_RESPONSE")
+
+            # Verify extraction fields in rendered prompt
+            assert "lattice project" in rendered_prompt
+            assert "2026-01-10T23:59:59Z" in rendered_prompt
+            assert "high" in rendered_prompt
+
+            # Verify context info includes extraction
+            assert context_info["template"] == "GOAL_RESPONSE"
+            assert context_info["extraction_id"] == str(mock_extraction_declaration.id)
+
+            # Verify result
+            assert result == mock_generation_result
+
+    @pytest.mark.asyncio
+    async def test_generate_with_query_extraction(
+        self,
+        mock_extraction_query: QueryExtraction,
+        mock_recent_messages: list[EpisodicMessage],
+        mock_semantic_facts: list[StableFact],
+        mock_generation_result: GenerationResult,
+    ) -> None:
+        """Test response generation with query extraction."""
+        mock_template = PromptTemplate(
+            prompt_key="QUERY_RESPONSE",
+            template=(
+                "Context: {episodic_context}\n"
+                "User: {user_message}\n"
+                "Query: {query}\n"
+                "Entities: {entities}"
+            ),
+            temperature=0.5,
+            version=1,
+            active=True,
+        )
+
+        with (
+            patch(
+                "lattice.core.response_generator.procedural.get_prompt"
+            ) as mock_get_prompt,
+            patch("lattice.core.response_generator.get_llm_client") as mock_get_client,
+        ):
+            mock_get_prompt.return_value = mock_template
+            mock_client = AsyncMock()
+            mock_client.complete.return_value = mock_generation_result
+            mock_get_client.return_value = mock_client
+
+            result, rendered_prompt, context_info = await generate_response(
+                user_message="When is the lattice deadline?",
+                semantic_facts=mock_semantic_facts,
+                recent_messages=mock_recent_messages,
+                extraction=mock_extraction_query,
+            )
+
+            # Verify template selection
+            mock_get_prompt.assert_called_once_with("QUERY_RESPONSE")
+
+            # Verify query field in rendered prompt
+            assert "When is the lattice project deadline?" in rendered_prompt
+
+            # Verify temperature from template is used
+            mock_client.complete.assert_called_once()
+            call_kwargs = mock_client.complete.call_args
+            assert call_kwargs[1]["temperature"] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_generate_with_activity_extraction(
+        self,
+        mock_extraction_activity: QueryExtraction,
+        mock_recent_messages: list[EpisodicMessage],
+        mock_semantic_facts: list[StableFact],
+        mock_generation_result: GenerationResult,
+    ) -> None:
+        """Test response generation with activity update extraction."""
+        mock_template = PromptTemplate(
+            prompt_key="ACTIVITY_RESPONSE",
+            template=(
+                "Context: {episodic_context}\n"
+                "User: {user_message}\n"
+                "Activity: {activity}\n"
+                "Entities: {entities}"
+            ),
+            temperature=0.7,
+            version=1,
+            active=True,
+        )
+
+        with (
+            patch(
+                "lattice.core.response_generator.procedural.get_prompt"
+            ) as mock_get_prompt,
+            patch("lattice.core.response_generator.get_llm_client") as mock_get_client,
+        ):
+            mock_get_prompt.return_value = mock_template
+            mock_client = AsyncMock()
+            mock_client.complete.return_value = mock_generation_result
+            mock_get_client.return_value = mock_client
+
+            result, rendered_prompt, context_info = await generate_response(
+                user_message="Spent 3 hours coding today",
+                semantic_facts=mock_semantic_facts,
+                recent_messages=mock_recent_messages,
+                extraction=mock_extraction_activity,
+            )
+
+            # Verify template selection
+            mock_get_prompt.assert_called_once_with("ACTIVITY_RESPONSE")
+
+            # Verify activity field in rendered prompt
+            assert "coding" in rendered_prompt
+
+    @pytest.mark.asyncio
+    async def test_generate_with_conversation_extraction(
+        self,
+        mock_extraction_conversation: QueryExtraction,
+        mock_recent_messages: list[EpisodicMessage],
+        mock_semantic_facts: list[StableFact],
+        mock_generation_result: GenerationResult,
+    ) -> None:
+        """Test response generation with conversation extraction."""
+        mock_template = PromptTemplate(
+            prompt_key="CONVERSATION_RESPONSE",
+            template=(
+                "Context: {episodic_context}\n"
+                "User: {user_message}\n"
+                "Continuation: {continuation}\n"
+                "Entities: {entities}"
+            ),
+            temperature=0.7,
+            version=1,
+            active=True,
+        )
+
+        with (
+            patch(
+                "lattice.core.response_generator.procedural.get_prompt"
+            ) as mock_get_prompt,
+            patch("lattice.core.response_generator.get_llm_client") as mock_get_client,
+        ):
+            mock_get_prompt.return_value = mock_template
+            mock_client = AsyncMock()
+            mock_client.complete.return_value = mock_generation_result
+            mock_get_client.return_value = mock_client
+
+            result, rendered_prompt, context_info = await generate_response(
+                user_message="Just made some tea",
+                semantic_facts=mock_semantic_facts,
+                recent_messages=mock_recent_messages,
+                extraction=mock_extraction_conversation,
+            )
+
+            # Verify template selection
+            mock_get_prompt.assert_called_once_with("CONVERSATION_RESPONSE")
+
+            # Verify continuation field in rendered prompt
+            assert "yes" in rendered_prompt  # continuation=True -> "yes"
+
+    @pytest.mark.asyncio
+    async def test_generate_without_extraction_legacy(
+        self,
+        mock_recent_messages: list[EpisodicMessage],
+        mock_semantic_facts: list[StableFact],
+        mock_basic_template: PromptTemplate,
+        mock_generation_result: GenerationResult,
+    ) -> None:
+        """Test backward compatibility when extraction is None."""
+        with (
+            patch(
+                "lattice.core.response_generator.procedural.get_prompt"
+            ) as mock_get_prompt,
+            patch("lattice.core.response_generator.get_llm_client") as mock_get_client,
+        ):
+            mock_get_prompt.return_value = mock_basic_template
+            mock_client = AsyncMock()
+            mock_client.complete.return_value = mock_generation_result
+            mock_get_client.return_value = mock_client
+
+            result, rendered_prompt, context_info = await generate_response(
+                user_message="Hello",
+                semantic_facts=mock_semantic_facts,
+                recent_messages=mock_recent_messages,
+                extraction=None,
+            )
+
+            # Verify BASIC_RESPONSE is used for backward compatibility
+            mock_get_prompt.assert_called_once_with("BASIC_RESPONSE")
+
+            # Verify context info shows no extraction
+            assert context_info["extraction_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_generate_template_fallback(
+        self,
+        mock_extraction_declaration: QueryExtraction,
+        mock_recent_messages: list[EpisodicMessage],
+        mock_semantic_facts: list[StableFact],
+        mock_basic_template: PromptTemplate,
+        mock_generation_result: GenerationResult,
+    ) -> None:
+        """Test fallback to BASIC_RESPONSE when selected template doesn't exist."""
+        with (
+            patch(
+                "lattice.core.response_generator.procedural.get_prompt"
+            ) as mock_get_prompt,
+            patch("lattice.core.response_generator.get_llm_client") as mock_get_client,
+        ):
+            # First call returns None (template not found), second call returns basic template
+            mock_get_prompt.side_effect = [None, mock_basic_template]
+            mock_client = AsyncMock()
+            mock_client.complete.return_value = mock_generation_result
+            mock_get_client.return_value = mock_client
+
+            result, rendered_prompt, context_info = await generate_response(
+                user_message="Test message",
+                semantic_facts=mock_semantic_facts,
+                recent_messages=mock_recent_messages,
+                extraction=mock_extraction_declaration,
+            )
+
+            # Verify both templates were tried
+            assert mock_get_prompt.call_count == 2
+            mock_get_prompt.assert_any_call("GOAL_RESPONSE")
+            mock_get_prompt.assert_any_call("BASIC_RESPONSE")
+
+    @pytest.mark.asyncio
+    async def test_generate_with_graph_triples(
+        self,
+        mock_extraction_query: QueryExtraction,
+        mock_recent_messages: list[EpisodicMessage],
+        mock_semantic_facts: list[StableFact],
+        mock_prompt_template: PromptTemplate,
+        mock_generation_result: GenerationResult,
+    ) -> None:
+        """Test response generation includes graph triples in context."""
+        graph_triples = [
+            {
+                "subject_content": "lattice project",
+                "predicate": "has deadline",
+                "object_content": "Friday",
+            },
+            {
+                "subject_content": "user",
+                "predicate": "working on",
+                "object_content": "lattice project",
+            },
+        ]
+
+        with (
+            patch(
+                "lattice.core.response_generator.procedural.get_prompt"
+            ) as mock_get_prompt,
+            patch("lattice.core.response_generator.get_llm_client") as mock_get_client,
+        ):
+            mock_get_prompt.return_value = mock_prompt_template
+            mock_client = AsyncMock()
+            mock_client.complete.return_value = mock_generation_result
+            mock_get_client.return_value = mock_client
+
+            result, rendered_prompt, context_info = await generate_response(
+                user_message="When is the deadline?",
+                semantic_facts=mock_semantic_facts,
+                recent_messages=mock_recent_messages,
+                graph_triples=graph_triples,
+                extraction=mock_extraction_query,
+            )
+
+            # Verify graph triples are formatted in semantic context
+            assert "lattice project has deadline Friday" in rendered_prompt
+            assert "user working on lattice project" in rendered_prompt
+
+            # Verify context info includes graph count
+            assert context_info["graph"] == 2
+
+    @pytest.mark.asyncio
+    async def test_generate_empty_extraction_fields(
+        self,
+        mock_recent_messages: list[EpisodicMessage],
+        mock_semantic_facts: list[StableFact],
+    ) -> None:
+        """Test handling of extraction with empty/None fields."""
+        extraction = QueryExtraction(
+            id=uuid.uuid4(),
+            message_id=uuid.uuid4(),
+            message_type="conversation",
+            entities=[],  # Empty list
+            predicates=[],
+            time_constraint=None,
+            activity=None,
+            query=None,
+            urgency=None,
+            continuation=False,
+            rendered_prompt="test",
+            raw_response="test",
+            created_at=datetime.now(UTC),
+        )
+
+        mock_template = PromptTemplate(
+            prompt_key="CONVERSATION_RESPONSE",
+            template=(
+                "Context: {episodic_context}\n"
+                "Entities: {entities}\n"
+                "Activity: {activity}\n"
+                "Query: {query}"
+            ),
+            temperature=0.7,
+            version=1,
+            active=True,
+        )
+
+        mock_result = GenerationResult(
+            content="Response",
+            model="test",
+            provider="test",
+            prompt_tokens=10,
+            completion_tokens=10,
+            total_tokens=20,
+            cost_usd=0.001,
+            latency_ms=100,
+            temperature=0.7,
+        )
+
+        with (
+            patch(
+                "lattice.core.response_generator.procedural.get_prompt"
+            ) as mock_get_prompt,
+            patch("lattice.core.response_generator.get_llm_client") as mock_get_client,
+        ):
+            mock_get_prompt.return_value = mock_template
+            mock_client = AsyncMock()
+            mock_client.complete.return_value = mock_result
+            mock_get_client.return_value = mock_client
+
+            result, rendered_prompt, context_info = await generate_response(
+                user_message="Hello",
+                semantic_facts=mock_semantic_facts,
+                recent_messages=mock_recent_messages,
+                extraction=extraction,
+            )
+
+            # Verify empty fields are handled gracefully
+            assert "Entities: None" in rendered_prompt
+            assert "Activity: N/A" in rendered_prompt
+            assert "Query: N/A" in rendered_prompt


### PR DESCRIPTION
## Summary
Implements specialized response templates that enable message-type-specific response generation as part of the Query Extraction Service (Issue #61 Phase 2).

This is PR 3 of 5 for Phase 2:
- ✅ PR 1: Extraction Infrastructure (#66 - merged)
- ✅ PR 2: Entity Resolution (#67 - merged)  
- 🚧 PR 3: **Response Templates (this PR)**
- ⏭️ PR 4: Pipeline Integration (not started)
- ⏭️ PR 5: Monitoring & Refinement (not started)

## Changes

### 1. Database Migration: `014_response_templates.sql`
Adds 4 specialized prompt templates optimized for different message types:
- **GOAL_RESPONSE** (temp=0.7): Warm, supportive tone for declarations and commitments
- **QUERY_RESPONSE** (temp=0.5): Direct, factual tone for information queries
- **ACTIVITY_RESPONSE** (temp=0.7): Casual, interested tone for activity updates
- **CONVERSATION_RESPONSE** (temp=0.7): Natural, curious tone for general chat

Each template includes:
- Specific tone guidelines and examples
- "Good vs Bad" response examples
- Explicit anti-patterns (avoids AI clichés)
- Placeholders for extraction fields (entities, query, activity, time_constraint, urgency, continuation)

### 2. Core Logic: `lattice/core/response_generator.py`
- **`select_response_template()`**: Maps QueryExtraction message_type to appropriate template
  - Defaults to BASIC_RESPONSE for None extraction (backward compatibility)
  - Defaults unknown types to CONVERSATION_RESPONSE (safest fallback)
- **Enhanced `generate_response()`**:
  - Accepts optional `extraction` parameter with message metadata
  - Uses template-specific temperature instead of hardcoded 0.7
  - Implements placeholder filtering for backward compatibility (uses regex to only pass params the template needs)
  - Populates extraction fields (entities, query, activity, time_constraint, urgency, continuation)
  - Includes extraction_id in context_info for audit trail

### 3. Comprehensive Tests: `tests/unit/test_response_templates.py`
- 13 unit tests covering all scenarios:
  - Template selection for all 4 message types
  - Backward compatibility (extraction=None uses BASIC_RESPONSE)
  - Template fallback when requested template doesn't exist
  - Graph triple integration
  - Empty extraction fields handling
  - Unknown message type handling

## Key Design Decisions

### 1. Placeholder Filtering (Backward Compatibility)
Uses regex to extract placeholders from template, then only passes parameters that exist:
```python
template_placeholders = set(re.findall(r"\{(\w+)\}", prompt_template.template))
filtered_params = {key: value for key, value in template_params.items() if key in template_placeholders}
```
This allows BASIC_RESPONSE (which doesn't have extraction fields) to coexist with the new templates.

### 2. Temperature per Template
Each template specifies its own temperature in the database:
- 0.5 for QUERY_RESPONSE (factual consistency)
- 0.7 for creative responses (GOAL, ACTIVITY, CONVERSATION)

This enables the Dreaming Cycle to optimize each template independently.

### 3. No Pipeline Integration Yet
This PR **does not** wire templates into the main pipeline. That's intentional—PR 4 will handle pipeline integration. This allows templates to be reviewed and tested independently.

## Testing

```bash
make check-all  # Passes: lint, type-check, discord-check
make test       # 106 passed, 7 skipped
```

Coverage: 75% for response_generator.py (uncovered lines are fallback paths and existing split_response function)

## Migration Safety

Migration is idempotent: uses `ON CONFLICT DO NOTHING`
Can be applied multiple times safely.

## Code Review

Received **Grade A** from reviewer subagent:
- ✅ Excellent template design with concrete examples
- ✅ Clean separation of concerns
- ✅ Comprehensive test coverage
- ✅ Backward compatibility maintained
- ✅ Follows project standards (AGENTS.md)

Minor suggestions addressed:
- Moved `import re` to top of file
- Added `MAX_GRAPH_TRIPLES` constant for configurability

## Next Steps (PR 4: Pipeline Integration)

1. Wire template selection into `pipeline.py`
2. Call `extract_query_structure()` before `generate_response()`
3. Pass extraction to `generate_response()`
4. Add integration tests exercising full flow
5. Document behavior when extraction fails mid-pipeline

---

**Related**: #61 (Graph-First Semantic Memory)