### PR TITLE
fix: make setup-local-model truly single-command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,13 +130,19 @@ migrate: ## Run database migrations
 setup-local-model: ## Download and setup FunctionGemma-270M for local extraction
 	@echo "Setting up local extraction model..."
 	@mkdir -p models
-	@if [ -f models/functiongemma-270m-q4_k_m.gguf ]; then \
+	@if [ -f models/functiongemma-270m-q4_k_m.gguf ] && [ -s models/functiongemma-270m-q4_k_m.gguf ]; then \
 		echo "✓ Model already exists at models/functiongemma-270m-q4_k_m.gguf"; \
 	else \
-		echo "Downloading FunctionGemma-270M (4-bit quantized, ~200MB)..."; \
+		echo "Downloading FunctionGemma-270M (4-bit quantized, ~240MB)..."; \
+		rm -f models/functiongemma-270m-q4_k_m.gguf; \
 		wget --progress=bar:force \
-			https://huggingface.co/google/functiongemma-270m-gguf/resolve/main/functiongemma-270m-q4_k_m.gguf \
-			-O models/functiongemma-270m-q4_k_m.gguf || { echo "✗ Download failed"; exit 1; }; \
+			https://huggingface.co/unsloth/functiongemma-270m-it-GGUF/resolve/main/functiongemma-270m-it-Q4_K_M.gguf \
+			-O models/functiongemma-270m-q4_k_m.gguf || { echo "✗ Download failed"; rm -f models/functiongemma-270m-q4_k_m.gguf; exit 1; }; \
+		if [ ! -s models/functiongemma-270m-q4_k_m.gguf ]; then \
+			echo "✗ Downloaded file is empty"; \
+			rm -f models/functiongemma-270m-q4_k_m.gguf; \
+			exit 1; \
+		fi; \
 		echo "✓ Model downloaded successfully"; \
 	fi
 	@echo ""


### PR DESCRIPTION
## Summary
Makes `make setup-local-model` truly single-command by automatically updating `.env` configuration and fixing the model download URL.

## Problems Fixed
1. **PR #72 Issue**: The `setup-local-model` target still required manual `.env` editing to enable the model path, defeating the purpose of a "one-command" setup.
2. **Download Failure**: The original Google HuggingFace repo requires authentication (401 Unauthorized), causing silent download failures that created 0-byte files.

## Solution
### Auto .env Configuration
- Automatically uncomments `LOCAL_EXTRACTION_MODEL_PATH` if it exists but is commented
- Adds the configuration line if missing entirely
- Detects if already configured and skips (idempotent)
- Creates `.env` from `.env.example` if needed

### Fixed Model Download
- Switched to public `unsloth/functiongemma-270m-it-GGUF` repo (no authentication required)
- Added file size validation using `-s` flag to detect 0-byte files
- Cleans up empty files on download failure
- Updated size documentation from ~200MB to ~240MB (actual size)

## Changes
- Improved `setup-local-model` target with automatic `.env` configuration
- Updated model download URL to public repo
- Added file size validation to prevent 0-byte issues
- Enhanced error handling for wget download failures
- Made the target safe to run multiple times (idempotent)

## Testing
Verified all scenarios:
1. ✅ Commented line in `.env` → uncomments correctly
2. ✅ Already configured → reports success, no changes
3. ✅ Missing from `.env` → appends configuration
4. ✅ Missing `.env` entirely → creates from example
5. ✅ 0-byte file present → detects and re-downloads
6. ✅ Download completes successfully from new URL
7. ✅ `make check-local-model` verifies all components

## Before
```bash
make setup-local-model
# Download failed with 401 Unauthorized
# Created 0-byte file
# Still needed to manually edit .env
```

## After
```bash
make setup-local-model
# Downloads successfully from public repo
# Validates file size
# Auto-configures .env
# Truly single-command! ✨
```