### PR TITLE
fix: add postgres restart policy and update docker-restart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,9 @@ docker-rebuild: ## Rebuild and restart services (use --no-cache for clean rebuil
 	docker compose build
 	docker compose up -d
 
-docker-restart: ## Quick restart bot (for code changes, no rebuild)
-	docker compose restart bot
-	@echo "Bot restarted. View logs with: make docker-logs-bot"
+docker-restart: ## Restart all services
+	docker compose restart
+	@echo "All services restarted. View logs with: make docker-logs"
 
 docker-shell: ## Open shell in bot container
 	docker compose exec bot /bin/bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    restart: unless-stopped
 
   # Lattice bot application
   bot:


### PR DESCRIPTION
## Summary
- Add `restart: unless-stopped` to postgres service in docker-compose.yml
- Update `make docker-restart` to restart all services instead of just the bot

## Why
- Postgres was exiting without auto-restart, causing the bot to fail on database connection
- `docker-restart` now restarts all services for complete environment refresh

## Changes
- docker-compose.yml: Added restart policy to postgres service
- Makefile: Changed docker-restart to run `docker compose restart` (all services)