### PR TITLE
fix: add prompt audit records for proactive messages and dynamic template version (#91, #92)

### DIFF
--- a/lattice/core/response_generator.py
+++ b/lattice/core/response_generator.py
@@ -267,6 +267,7 @@ async def generate_response(
     # Build context info for audit (removed context_config in Design D)
     context_info = {
         "template": template_name,
+        "template_version": prompt_template.version,
         "extraction_id": str(extraction.id) if extraction else None,
     }
 

--- a/lattice/discord_client/bot.py
+++ b/lattice/discord_client/bot.py
@@ -340,8 +340,9 @@ class LatticeBot(commands.Bot):
                 "extraction_id": context_info.get("extraction_id"),
             }
 
-            # Get template key from context_info (defaults to BASIC_RESPONSE for backward compat)
+            # Get template key and version from context_info (defaults to BASIC_RESPONSE for backward compat)
             template_key = context_info.get("template", "BASIC_RESPONSE")
+            template_version = context_info.get("template_version", 1)
 
             # Store episodic messages and prompt audits
             for bot_msg in bot_messages:
@@ -360,7 +361,7 @@ class LatticeBot(commands.Bot):
                     rendered_prompt=rendered_prompt,
                     response_content=bot_msg.content,
                     main_discord_message_id=bot_msg.id,
-                    template_version=1,  # TODO: Get from prompt_registry
+                    template_version=template_version,
                     message_id=message_id,
                     model=response_result.model,
                     provider=response_result.provider,
@@ -380,7 +381,7 @@ class LatticeBot(commands.Bot):
                     audit_id=audit_id,
                     performance={
                         "prompt_key": template_key,
-                        "version": 1,
+                        "version": template_version,
                         "model": response_result.model,
                         "latency_ms": response_result.latency_ms,
                         "cost_usd": response_result.cost_usd or 0,

--- a/lattice/scheduler/triggers.py
+++ b/lattice/scheduler/triggers.py
@@ -28,6 +28,15 @@ class ProactiveDecision:
     content: str | None
     reason: str
     channel_id: int | None = None
+    # Generation metadata for audit trail
+    rendered_prompt: str | None = None
+    template_version: int | None = None
+    model: str | None = None
+    provider: str | None = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    cost_usd: float | None = None
+    latency_ms: int | None = None
 
 
 async def get_current_interval() -> int:
@@ -180,6 +189,15 @@ async def decide_proactive() -> ProactiveDecision:
             content=content,
             reason=decision.get("reason", "No reason provided"),
             channel_id=channel_id,
+            # Capture generation metadata for audit trail
+            rendered_prompt=prompt,
+            template_version=prompt_template.version,
+            model=result.model,
+            provider=result.provider,
+            prompt_tokens=result.prompt_tokens,
+            completion_tokens=result.completion_tokens,
+            cost_usd=result.cost_usd,
+            latency_ms=result.latency_ms,
         )
 
     except json.JSONDecodeError:


### PR DESCRIPTION
## Summary

This PR fixes two issues related to prompt audit records:
- **#91**: Fix hardcoded template_version in bot.py
- **#92**: Add prompt audit records for proactive messages

## Changes

### Issue #91: Dynamic Template Version
- Modified `response_generator.py` to include `template_version` in `context_info`
- Updated `bot.py` to extract and use actual template version instead of hardcoded `1`
- Applied to both prompt audit storage and dream channel mirror

### Issue #92: Proactive Message Audits
- Extended `ProactiveDecision` dataclass to capture LLM generation metadata
- Modified `decide_proactive()` to store rendered prompt and template version
- Updated `runner.py` to store prompt audit after sending proactive message
- Enhanced `build_proactive_mirror()` to display audit info and enable interactive buttons

## Testing
- ✅ All 156 tests pass
- ✅ No type errors (mypy clean)
- ✅ No linting errors (ruff clean)
- ✅ All pre-commit hooks passed
- ✅ Code reviewed by reviewer agent

## Impact
- Completes audit trail for Dreaming Cycle analysis
- Enables prompt optimization for proactive messages
- Ensures accurate template version tracking across all message types

Fixes #91
Fixes #92