### PR TITLE
refactor: Unify extraction into single LLM call

### DIFF
--- a/feedback_analysis.md
+++ b/feedback_analysis.md
@@ -1,0 +1,76 @@
+# User Feedback Analysis
+
+**Generated:** 2026-01-07
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Total Feedback | 13 |
+| Positive | 3 |
+| Negative | 9 |
+| Neutral | 0 |
+
+## Feedback Entries with Context
+
+| Sentiment | User Message | Extracted | Feedback |
+|-----------|--------------|-----------|----------|
+| **negative** | (empty - message not stored) | N/A | (Quick negative feedback) |
+| **positive** | (empty) | N/A | (Quick positive feedback) |
+| **negative** | `what else do you know about me?` | `[]` | there should be no objectives extracted |
+| **positive** | `what's my name?` | `[]` | (Quick positive feedback) |
+| **positive** | (empty - proactive message) | N/A | (Quick positive feedback) |
+| **negative** | `what's my name` | `[]` | (Quick negative feedback) |
+| **negative** | `I really need to register to courses by tonight` | `[{"subject":"User","predicate":"needs_to_register","object":"courses"}]` | only extract as an objective. not as a triple. we need better instructions to separate these. |
+| **negative** | `we're not hunting for names. we are establishing base lines` | `[{"subject":"User","predicate":"establishes","object":"base lines"}]` | way too eager to extract. nothing should be extracted here. |
+| **negative** | `what is your name?` | `[]` | nothing should be extracted |
+| **positive** | `i live in richmond canada, right next to vancouver, canada` | 3 triples (lives_in, is_near, is_in) | (Quick positive feedback) |
+| **negative** | `wrong. your name is Lattice` | `[{"subject":"User","predicate":"has_name","object":"Lattice"}]` | wrong subject. should be: assistant -> has_name -> Lattice. no objective |
+| **negative** | `what is your name?` | `[]` | same problem. questions should not be a source of extractions |
+| **negative** | `what is my name` | `[]` | that is not an objective. this should be classified as a question and nothing extracted |
+
+## Key Patterns in Feedback
+
+### Positive Cases (3)
+- Correct handling of questions (no extraction expected)
+- Good triple extraction for factual statements (e.g., location information)
+
+### Negative Cases (9)
+Issues identified:
+
+1. **Over-extraction** (3 cases)
+   - System extracting from metacommentary that shouldn't be captured
+   - Example: "we're not hunting for names. we are establishing base lines" → extracted `{"subject":"User","predicate":"establishes","object":"base lines"}`
+   - Example: "I really need to register to courses by tonight" → extracted as triple instead of objective
+
+2. **Wrong Entity Subjects** (1 case)
+   - User corrected: "User has_name Lattice" → should be "Assistant has_name Lattice"
+   - Bot incorrectly attributed the name to the user
+
+3. **Triple vs Objective Confusion** (1 case)
+   - Feedback explicitly states: "only extract as an objective. not as a triple"
+   - Need better instructions to separate extraction types
+
+4. **Questions Triggering Extraction** (2 cases)
+   - Questions like "what is your name?" and "what is my name" are triggering extraction attempts
+   - Should be classified as questions with no extraction
+
+5. **Empty Messages/Quick Feedback** (2 cases)
+   - Some messages not stored in raw_messages table
+   - Quick feedback buttons used without detailed comments
+
+## Recommendations
+
+1. Add explicit rules to skip extraction for:
+   - Questions (interrogative sentences)
+   - Metacommentary about the system itself
+   - Self-referential statements about the conversation
+
+2. Distinguish between triples and objectives in extraction prompts:
+   - Triples: factual relationships between entities
+   - Objectives: user-stated goals/intentions (salient statements of intent)
+
+3. Fix entity resolution:
+   - Assistant's name should be attributed to Assistant entity, not User
+
+4. Consider adding minimum salience thresholds for extraction

--- a/lattice/core/entity_extraction.py
+++ b/lattice/core/entity_extraction.py
@@ -2,6 +2,9 @@
 
 This module provides entity extraction for graph traversal.
 Extracted entities are used as starting points for multi-hop knowledge retrieval.
+
+Templates:
+- ENTITY_EXTRACTION: Extracts entity mentions for graph traversal (reactive flow)
 """
 
 import json
@@ -37,7 +40,6 @@ class EntityExtraction:
 
 
 # Type alias for backward compatibility
-# TODO: Remove in v2.0 - use EntityExtraction instead
 QueryExtraction: TypeAlias = EntityExtraction
 
 
@@ -46,12 +48,12 @@ async def extract_entities(
     message_content: str,
     context: str = "",
 ) -> QueryExtraction:
-    """Extract structured information from a user message.
+    """Extract entity mentions from a user message.
 
     This function:
-    1. Fetches the QUERY_EXTRACTION prompt template
+    1. Fetches the ENTITY_EXTRACTION prompt template
     2. Renders the prompt with message content and context
-    3. Calls OpenRouter API for extraction
+    3. Calls LLM API for extraction
     4. Parses JSON response into extraction fields
     5. Stores extraction in message_extractions table
 
@@ -61,16 +63,16 @@ async def extract_entities(
         context: Additional context (recent messages, objectives, etc.)
 
     Returns:
-        QueryExtraction object with structured fields
+        EntityExtraction object with structured fields
 
     Raises:
         ValueError: If prompt template not found
         json.JSONDecodeError: If LLM response is not valid JSON
     """
     # 1. Fetch prompt template
-    prompt_template = await get_prompt("QUERY_EXTRACTION")
+    prompt_template = await get_prompt("ENTITY_EXTRACTION")
     if not prompt_template:
-        msg = "QUERY_EXTRACTION prompt template not found in prompt_registry"
+        msg = "ENTITY_EXTRACTION prompt template not found in prompt_registry"
         raise ValueError(msg)
 
     # 2. Render prompt with message content and context
@@ -258,7 +260,3 @@ async def get_message_extraction(message_id: uuid.UUID) -> QueryExtraction | Non
             extraction_method=extraction_data.get("_extraction_method", "api"),
             created_at=row["created_at"],
         )
-
-
-# Backward compatibility alias
-extract_query_structure = extract_entities

--- a/lattice/utils/memory_parsing.py
+++ b/lattice/utils/memory_parsing.py
@@ -1,0 +1,218 @@
+"""Memory extraction parsing utilities for unified triple and objective extraction."""
+
+import json
+import logging
+from typing import TypedDict
+
+
+logger = logging.getLogger(__name__)
+
+MIN_SALIENCY = 0.0
+MAX_SALIENCY = 1.0
+MIN_SALIENCY_DELTA = 0.01
+
+
+class ParsedTriple(TypedDict):
+    """Parsed semantic triple."""
+
+    subject: str
+    predicate: str
+    object: str
+
+
+class ParsedObjective(TypedDict):
+    """Parsed objective."""
+
+    description: str
+    saliency: float
+    status: str
+
+
+class ParsedMemoryExtraction(TypedDict):
+    """Result of parsing MEMORY_EXTRACTION response."""
+
+    triples: list[ParsedTriple]
+    objectives: list[ParsedObjective]
+
+
+PREDICATE_SYNONYMS: dict[str, list[str]] = {
+    "likes": ["likes", "enjoys", "loves", "fond_of", "appreciates"],
+    "works_at": ["works_at", "employed_at", "job_at", "position_at", "works_for"],
+    "created": ["created", "built", "made", "constructed", "developed", "authored"],
+    "located_in": ["located_in", "based_in", "situated_in", "in"],
+    "knows": ["knows", "acquainted_with", "friend_of", "familiar_with"],
+    "member_of": ["member_of", "part_of", "belongs_to", "affiliated_with"],
+}
+
+MIN_SALIENCY = 0.0
+MAX_SALIENCY = 1.0
+VALID_STATUSES = frozenset({"pending", "completed", "archived"})
+MIN_CODE_BLOCK_LINES = 2
+
+
+def _normalize_predicate(predicate: str) -> str:
+    """Normalize predicate to canonical form.
+
+    Args:
+        predicate: Raw predicate string from triple
+
+    Returns:
+        Normalized predicate string
+    """
+    normalized = predicate.lower().strip()
+    for canonical, synonyms in PREDICATE_SYNONYMS.items():
+        if normalized in synonyms:
+            return canonical
+    return normalized
+
+
+def _parse_triples_from_list(triples: list) -> list[ParsedTriple]:
+    """Parse triples from a list, validating structure.
+
+    Args:
+        triples: List of triple dicts from JSON
+
+    Returns:
+        List of validated triples
+    """
+    validated: list[ParsedTriple] = []
+    for item in triples:
+        if not isinstance(item, dict):
+            logger.warning(
+                "parse_memory_extraction: expected dict for triple, got %s", type(item)
+            )
+            continue
+
+        if (
+            "subject" in item
+            and "predicate" in item
+            and "object" in item
+            and all(
+                isinstance(item[k], str) for k in ("subject", "predicate", "object")
+            )
+        ):
+            validated.append(
+                {
+                    "subject": item["subject"].strip(),
+                    "predicate": _normalize_predicate(item["predicate"]),
+                    "object": item["object"].strip(),
+                }
+            )
+        else:
+            logger.warning("parse_memory_extraction: invalid triple format: %s", item)
+
+    return validated
+
+
+def _parse_objectives_from_list(objectives: list) -> list[ParsedObjective]:
+    """Parse objectives from a list, validating structure.
+
+    Args:
+        objectives: List of objective dicts from JSON
+
+    Returns:
+        List of validated objectives
+    """
+    validated: list[ParsedObjective] = []
+    for item in objectives:
+        if not isinstance(item, dict):
+            logger.warning(
+                "parse_memory_extraction: expected dict for objective, got %s",
+                type(item),
+            )
+            continue
+
+        description = item.get("description")
+        if (
+            not description
+            or not isinstance(description, str)
+            or not description.strip()
+        ):
+            logger.warning(
+                "parse_memory_extraction: missing or invalid description: %s", item
+            )
+            continue
+
+        saliency = item.get("saliency", 0.5)
+        if not isinstance(saliency, (int, float)):
+            logger.warning(
+                "parse_memory_extraction: invalid saliency, using default: %s", item
+            )
+            saliency = 0.5
+        saliency = float(saliency)
+        saliency = max(MIN_SALIENCY, min(MAX_SALIENCY, saliency))
+
+        status = item.get("status", "pending")
+        status = "pending" if not isinstance(status, str) else status.lower().strip()
+        if status not in VALID_STATUSES:
+            logger.warning(
+                "parse_memory_extraction: invalid status '%s', using 'pending'", status
+            )
+            status = "pending"
+
+        validated.append(
+            {
+                "description": description.strip(),
+                "saliency": saliency,
+                "status": status,
+            }
+        )
+
+    return validated
+
+
+def parse_memory_extraction(raw_output: str) -> ParsedMemoryExtraction:
+    """Parse LLM output from MEMORY_EXTRACTION into structured triples and objectives.
+
+    Args:
+        raw_output: Raw string output from LLM
+
+    Returns:
+        ParsedMemoryExtraction with validated triples and objectives
+    """
+    cleaned = raw_output.strip()
+
+    try:
+        if cleaned.startswith("```"):
+            lines = cleaned.split("\n")
+            if len(lines) >= MIN_CODE_BLOCK_LINES:
+                cleaned = "\n".join(lines[1:-1])
+                if cleaned.lower().startswith("json"):
+                    cleaned = cleaned[4:].strip()
+
+        data = json.loads(cleaned)
+
+        if not isinstance(data, dict):
+            logger.warning("parse_memory_extraction: expected dict, got %s", type(data))
+            return {"triples": [], "objectives": []}
+
+        triples_raw = data.get("triples", [])
+        objectives_raw = data.get("objectives", [])
+
+        if not isinstance(triples_raw, list):
+            logger.warning(
+                "parse_memory_extraction: expected triples to be list, got %s",
+                type(triples_raw),
+            )
+            triples_raw = []
+
+        if not isinstance(objectives_raw, list):
+            logger.warning(
+                "parse_memory_extraction: expected objectives to be list, got %s",
+                type(objectives_raw),
+            )
+            objectives_raw = []
+
+        return {
+            "triples": _parse_triples_from_list(triples_raw),
+            "objectives": _parse_objectives_from_list(objectives_raw),
+        }
+
+    except json.JSONDecodeError:
+        logger.warning(
+            "parse_memory_extraction: JSON decode error: %s", raw_output[:100]
+        )
+        return {"triples": [], "objectives": []}
+    except Exception:
+        logger.exception("parse_memory_extraction: unexpected error")
+        return {"triples": [], "objectives": []}

--- a/scripts/seed.sql
+++ b/scripts/seed.sql
@@ -44,7 +44,7 @@ Respond naturally based on what the user is saying:
 **User:** "Spent 4 hours coding today"
 **Response:** "Nice session! How''d it go?"
 
-**User:** "That''s awesome!"
+**User:** "That's awesome!"
 **Response:** "Glad to hear it!"
 
 **User:** "Did I talk to Alice this week?"
@@ -53,224 +53,10 @@ Respond naturally based on what the user is saying:
 Respond naturally and helpfully.', 0.7, 1)
 ON CONFLICT (prompt_key) DO NOTHING;
 
--- ENTITY_NORMALIZATION (v1, temp=0.2)
+-- ENTITY_EXTRACTION (v3, temp=0.2)
+-- Previously QUERY_EXTRACTION v2 - renamed for clarity
 INSERT INTO prompt_registry (prompt_key, template, temperature, version)
-VALUES ('ENTITY_NORMALIZATION', E'You are an entity normalization system. Given an entity mention and context, normalize it to a canonical form.
-
-## Task
-Normalize the entity mention to its canonical form. Consider:
-1. Canonical names (full names, proper nouns)
-2. Abbreviations and nicknames
-3. Context clues about identity
-4. Consistent capitalization and formatting
-
-## Input
-**Entity Mention:** {entity_mention}
-**Message Context:** {message_context}
-**Existing Entities:** {existing_entities}
-
-## Rules
-1. **Exact Match**: If the mention matches an existing entity (case-insensitive), return the existing canonical name
-2. **Normalization**: If it''s a variant (nickname, abbreviation, typo), return the canonical form
-3. **New Entity**: If it''s truly new, return a normalized canonical form
-4. **Preserve Meaning**: Do not over-normalize - "Python" and "python script" are different
-5. **Capitalization**: Use proper capitalization (e.g., "Alice" not "alice", "Python" not "python" for the language)
-
-## Examples
-
-**Input:**
-- Entity Mention: "mom"
-- Existing Entities: ["Alice", "Bob", "Mom"]
-- Context: "I talked to mom about the project"
-
-**Output:**
-{{
-  "canonical_name": "Mom",
-  "reasoning": "Direct match to existing entity, capitalized"
-}}
-
-**Input:**
-- Entity Mention: "alice"
-- Existing Entities: ["Alice Johnson", "Bob"]
-- Context: "alice helped me debug the code"
-
-**Output:**
-{{
-  "canonical_name": "Alice Johnson",
-  "reasoning": "Case-insensitive match to existing entity"
-}}
-
-**Input:**
-- Entity Mention: "lattice-ai"
-- Existing Entities: ["lattice", "Discord Bot"]
-- Context: "working on lattice-ai features"
-
-**Output:**
-{{
-  "canonical_name": "lattice",
-  "reasoning": "Variant of existing entity (hyphenated form)"
-}}
-
-**Input:**
-- Entity Mention: "Python"
-- Existing Entities: []
-- Context: "learning Python programming"
-
-**Output:**
-{{
-  "canonical_name": "Python",
-  "reasoning": "New entity, proper capitalization for programming language"
-}}
-
-**Input:**
-- Entity Mention: "john"
-- Existing Entities: ["Alice", "Bob"]
-- Context: "met john at the conference"
-
-**Output:**
-{{
-  "canonical_name": "John",
-  "reasoning": "New entity, proper name capitalization"
-}}
-
-## Output Format
-Return ONLY valid JSON (no markdown, no explanation):
-{{
-  "canonical_name": "Normalized Entity Name",
-  "reasoning": "Brief explanation of normalization decision"
-}}', 0.2, 1)
-ON CONFLICT (prompt_key) DO NOTHING;
-
--- OBJECTIVE_EXTRACTION (v1, temp=0.1)
-INSERT INTO prompt_registry (prompt_key, template, temperature, version)
-VALUES ('OBJECTIVE_EXTRACTION', E'You are analyzing a conversation to extract user goals and intentions.
-
-## Input
-Recent conversation context:
-{CONTEXT}
-
-## Task
-Extract user goals, objectives, or intentions that represent what the user wants to achieve.
-
-## Rules
-- Only extract goals that are explicitly stated or strongly implied
-- Be specific about what the user wants to accomplish
-- Saliency 0.0-1.0 based on explicitness and importance:
-  * 0.9-1.0: Explicit, high-priority goals ("I need to launch by Friday")
-  * 0.6-0.8: Clear but moderate urgency ("Want to learn Rust eventually")
-  * 0.3-0.5: Implied or exploratory ("Maybe I should refactor this")
-- MAX 3 objectives per turn
-- Skip if no clear goals are expressed
-- **For goal updates:** If user mentions progress on an existing goal, mark it as "completed" and include original description
-
-## Output Format
-Return ONLY a JSON array. No markdown formatting, no code fences.
-[{{"description": "What the user wants to achieve", "saliency": 0.7, "status": "pending"}}]
-If no valid objectives: []
-
-## Status Guidelines
-- **pending:** New goal or ongoing work
-- **completed:** User explicitly finished or achieved the goal
-- **archived:** Goal is abandoned or no longer relevant
-
-## Examples
-
-**Example 1: New explicit goal**
-User: "I want to build a successful startup this year"
-Output: [{{"description": "Build a successful startup", "saliency": 0.9, "status": "pending"}}]
-
-**Example 2: Goal completion**
-User: "Just launched my MVP!"
-Output: [{{"description": "Launch MVP", "saliency": 0.9, "status": "completed"}}]
-
-**Example 3: Multiple goals with varying saliency**
-User: "Need to fix that auth bug today, and eventually migrate to PostgreSQL"
-Output: [
-    {{"description": "Fix auth bug", "saliency": 0.9, "status": "pending"}},
-    {{"description": "Migrate to PostgreSQL", "saliency": 0.5, "status": "pending"}}
-]
-
-**Example 4: No goals**
-User: "Yeah that makes sense, thanks!"
-Output: []
-
-Begin extraction:', 0.1, 1)
-ON CONFLICT (prompt_key) DO NOTHING;
-
--- PROACTIVE_DECISION (v1, temp=0.7)
-INSERT INTO prompt_registry (prompt_key, template, temperature, version)
-VALUES ('PROACTIVE_DECISION', E'You are a warm, curious, and gently proactive AI companion. Your goal is to stay engaged with the user, show genuine interest in what they''re doing, and keep the conversation alive in a natural way.
-
-## Task
-Decide ONE action:
-1. Send a short proactive message to the user
-2. Wait {current_interval} minutes before checking again
-
-## Inputs
-- **Current Time:** {current_time} (Consider whether it''s an appropriate time to message - avoid late night/early morning unless there''s strong recent activity)
-- **Conversation Context:** {conversation_context}
-- **Active Goals:** {objectives_context}
-
-## Guidelines
-- **Time Sensitivity:** Check the current time - avoid messaging during typical sleep hours (11 PM - 7 AM local time) unless recent conversation suggests the user is active
-- **Variety:** Do not repeat the style of previous check-ins. Rotate between:
-    - **Progress Pull:** "How''s the [Task] treating you?"
-    - **Vibe Check:** "How are you holding up today?"
-    - **Low-Friction Presence:** "Just checking in—I''m here if you need a thought partner."
-    - **Curious Spark:** "What''s the latest with [Task/Goal]? Any fun breakthroughs?"
-    - **Gentle Encouragement:** "Rooting for you on [Task]—how''s it feeling?"
-    - **Thinking of You:** "Hey, you popped into my mind—how''s your day going?"
-    - **Light Support Offer:** "Still grinding on [Task]? Hit me up if you want to bounce ideas."
-- **Tone:** Concise (1-2 sentences max), warm, and peer-level—like chatting with a good friend. Avoid formal assistant language (no "As an AI..." or overly polished phrases).
-- Adapt the message naturally to the conversation context or active goals, but keep it light and non-pushy.
-
-## Output Format
-Return ONLY valid JSON:
-{{
-  "action": "message" | "wait",
-  "content": "Message text" | null,
-  "reason": "Justify the decision briefly, including which style you chose and why it fits now."
-}}', 0.7, 1)
-ON CONFLICT (prompt_key) DO NOTHING;
-
--- PROMPT_OPTIMIZATION (v1, temp=0.7)
-INSERT INTO prompt_registry (prompt_key, template, temperature, version)
-VALUES ('PROMPT_OPTIMIZATION', E'CURRENT TEMPLATE:
-{current_template}
-
-PERFORMANCE METRICS:
-- Total uses: {total_uses}
-- Feedback rate: {feedback_rate}
-- Success rate: {success_rate} ({positive_feedback} positive, {negative_feedback} negative)
-
-EXPERIENCE CASES (Real-world examples with context):
-{experience_cases}
-
-TASK: Optimize the current prompt template.
-1. Analyze the DETAILED experiences first—inspect the rendered prompts to see what episodic/semantic/graph context was provided.
-2. Check if the context quality contributed to poor responses (e.g., irrelevant facts, missing information, wrong archetype).
-3. Cross-reference the bot''s response with the user''s feedback and the "CURRENT TEMPLATE" provided above.
-4. Identify specific instructions or lack thereof in the current template that caused poor responses.
-4. Propose one improved template that fixes the main issues with minimal, targeted changes—preserve everything that already works.
-5. Explain each change and how it ties to the specific experiences provided (especially the detailed ones).
-6. Estimate realistic improvements.
-
-Respond ONLY with this simplified JSON (no extra text):
-{{
-  "proposed_template": "full improved template here",
-  "changes": [
-    {{"issue": "brief description of problem from feedback", "fix": "what you changed", "why": "expected benefit"}}
-  ],
-  "expected_improvements": "short paragraph on likely impact (e.g., clarity, consistency, success rate, context relevance)",
-  "confidence": 0.XX
-}}
-
-Prioritize clarity, minimal changes, and direct ties to the actual experiences (especially rendered prompt quality).', 0.7, 1)
-ON CONFLICT (prompt_key) DO NOTHING;
-
--- QUERY_EXTRACTION (v2, temp=0.2)
-INSERT INTO prompt_registry (prompt_key, template, temperature, version)
-VALUES ('QUERY_EXTRACTION', E'You are a message analysis system. Extract entity mentions for graph traversal.
+VALUES ('ENTITY_EXTRACTION', E'You are a message analysis system. Extract entity mentions for graph traversal.
 
 ## Input
 **Recent Context:** {context}
@@ -314,54 +100,209 @@ Return ONLY valid JSON (no markdown, no explanation):
 **Recent Context:** (No additional context)
 **Current User Message:** Starting work on the database migration
 **Output:**
-{"entities": ["database migration"]}', 0.2, 2)
+{"entities": ["database migration"]}', 0.2, 3)
 ON CONFLICT (prompt_key) DO NOTHING;
 
--- TRIPLE_EXTRACTION (v1, temp=0.1)
+-- MEMORY_EXTRACTION (v1, temp=0.1)
+-- Unified extraction: triples + objectives in single LLM call
 INSERT INTO prompt_registry (prompt_key, template, temperature, version)
-VALUES ('TRIPLE_EXTRACTION', E'You are analyzing a conversation to extract explicit relationships.
+VALUES ('MEMORY_EXTRACTION', E'You are analyzing a conversation to build persistent memory.
 
 ## Input
 Recent conversation context:
 {CONTEXT}
 
 ## Task
+Extract two types of information:
+
+### 1. Semantic Triples (relationships)
 Extract Subject-Predicate-Object triples that represent factual relationships.
 
-## Rules
+**Rules:**
 - Only extract relationships explicitly stated or strongly implied
 - Use canonical entity names (e.g., "Alice" not "she")
 - Predicates: lowercase, present tense (e.g., "likes", "owns", "works_at")
 - MAX 5 triples per turn
-- Skip if entities not clearly identified
-- **Skip pure greetings/small talk** ("hi", "thanks", "lol") unless they contain factual content
+- Skip pure greetings/small talk unless they contain factual content
+
+### 2. Objectives (goals)
+Extract user goals, objectives, or intentions.
+
+**Rules:**
+- Only extract goals explicitly stated or strongly implied
+- Be specific about what the user wants to accomplish
+- Saliency 0.0-1.0 based on explicitness and importance:
+  * 0.9-1.0: Explicit, high-priority goals ("I need to launch by Friday")
+  * 0.6-0.8: Clear but moderate urgency ("Want to learn Rust eventually")
+  * 0.3-0.5: Implied or exploratory ("Maybe I should refactor this")
+- MAX 3 objectives per turn
+- Skip if no clear goals are expressed
+- For goal updates: mark as "completed" if achieved
 
 ## Output Format
-Return ONLY a JSON array. No markdown formatting, no code fences.
-[{{"subject": "Entity Name", "predicate": "relationship_type", "object": "Target Entity"}}]
-If no valid triples: []
+Return ONLY valid JSON. No markdown, no code fences.
+{
+  "triples": [
+    {"subject": "Entity Name", "predicate": "relationship_type", "object": "Target Entity"}
+  ],
+  "objectives": [
+    {"description": "What the user wants to achieve", "saliency": 0.7, "status": "pending"}
+  ]
+}
+
+If no valid triples: "triples": []
+If no valid objectives: "objectives": []
+
+## Status Guidelines for Objectives
+- **pending:** New goal or ongoing work
+- **completed:** User explicitly finished or achieved the goal
+- **archived:** Goal is abandoned or no longer relevant
 
 ## Examples
 
-**Example 1: Clear relationships**
-User: "My cat Mittens loves chasing laser pointers"
-Output: [
-    {{"subject": "User", "predicate": "owns", "object": "Mittens"}},
-    {{"subject": "Mittens", "predicate": "is_a", "object": "cat"}},
-    {{"subject": "Mittens", "predicate": "likes", "object": "laser pointers"}}
-]
+**Example 1: Clear relationships and goals**
+User: "My cat Mittens loves chasing laser pointers. I want to build a successful startup this year"
+Output: {
+  "triples": [
+    {"subject": "User", "predicate": "owns", "object": "Mittens"},
+    {"subject": "Mittens", "predicate": "is_a", "object": "cat"},
+    {"subject": "Mittens", "predicate": "likes", "object": "laser pointers"}
+  ],
+  "objectives": [
+    {"description": "Build a successful startup", "saliency": 0.9, "status": "pending"}
+  ]
+}
 
-**Example 2: Skip non-factual content**
-User: "lol that''s hilarious"
-Output: []
+**Example 2: Goal completion**
+User: "Just launched my MVP!"
+Output: {
+  "triples": [],
+  "objectives": [
+    {"description": "Launch MVP", "saliency": 0.9, "status": "completed"}
+  ]
+}
 
-**Example 3: Technical relationships**
-User: "I''m using React with TypeScript for the frontend"
-Output: [
-    {{"subject": "User", "predicate": "uses", "object": "React"}},
-    {{"subject": "User", "predicate": "uses", "object": "TypeScript"}},
-    {{"subject": "React", "predicate": "used_for", "object": "frontend"}}
-]
+**Example 3: Technical relationships, multiple goals**
+User: "I'm using React with TypeScript. Need to fix auth bug today, eventually migrate to PostgreSQL"
+Output: {
+  "triples": [
+    {"subject": "User", "predicate": "uses", "object": "React"},
+    {"subject": "User", "predicate": "uses", "object": "TypeScript"}
+  ],
+  "objectives": [
+    {"description": "Fix auth bug", "saliency": 0.9, "status": "pending"},
+    {"description": "Migrate to PostgreSQL", "saliency": 0.5, "status": "pending"}
+  ]
+}
+
+**Example 4: No triples or objectives**
+User: "Yeah that makes sense, thanks! lol that's hilarious"
+Output: {
+  "triples": [],
+  "objectives": []
+}
 
 Begin extraction:', 0.1, 1)
+ON CONFLICT (prompt_key) DO NOTHING;
+
+-- ENTITY_NORMALIZATION (v1, temp=0.2)
+INSERT INTO prompt_registry (prompt_key, template, temperature, version)
+VALUES ('ENTITY_NORMALIZATION', E'You are an entity normalization system. Given an entity mention and context, normalize it to a canonical form.
+
+## Task
+Normalize the entity mention to its canonical form. Consider:
+1. Canonical names (full names, proper nouns)
+2. Abbreviations and nicknames
+3. Context clues about identity
+4. Consistent capitalization and formatting
+
+## Input
+**Entity Mention:** {entity_mention}
+**Message Context:** {message_context}
+**Existing Entities:** {existing_entities}
+
+## Rules
+1. **Exact Match**: If the mention matches an existing entity (case-insensitive), return the existing canonical name
+2. **Normalization**: If it''s a variant (nickname, abbreviation, typo), return the canonical form
+3. **New Entity**: If it''s truly new, return a normalized canonical form
+4. **Preserve Meaning**: Do not over-normalize - "Python" and "python script" are different
+5. **Capitalization**: Use proper capitalization (e.g., "Alice" not "alice", "Python" not "python" for the language)
+
+## Output Format
+Return ONLY valid JSON (no markdown, no explanation):
+{
+  "canonical_name": "Normalized Entity Name",
+  "reasoning": "Brief explanation of normalization decision"
+}', 0.2, 1)
+ON CONFLICT (prompt_key) DO NOTHING;
+
+-- PROACTIVE_DECISION (v1, temp=0.7)
+INSERT INTO prompt_registry (prompt_key, template, temperature, version)
+VALUES ('PROACTIVE_DECISION', E'You are a warm, curious, and gently proactive AI companion. Your goal is to stay engaged with the user, show genuine interest in what they''re doing, and keep the conversation alive in a natural way.
+
+## Task
+Decide ONE action:
+1. Send a short proactive message to the user
+2. Wait {current_interval} minutes before checking again
+
+## Inputs
+- **Current Time:** {current_time} (Consider whether it''s an appropriate time to message - avoid late night/early morning unless there''s strong recent activity)
+- **Conversation Context:** {conversation_context}
+- **Active Goals:** {objectives_context}
+
+## Guidelines
+- **Time Sensitivity:** Check the current time - avoid messaging during typical sleep hours (11 PM - 7 AM local time) unless recent conversation suggests the user is active
+- **Variety:** Do not repeat the style of previous check-ins. Rotate between:
+    - **Progress Pull:** "How''s the [Task] treating you?"
+    - **Vibe Check:** "How are you holding up today?"
+    - **Low-Friction Presence:** "Just checking in—I''m here if you need a thought partner."
+    - **Curious Spark:** "What''s the latest with [Task/Goal]? Any fun breakthroughs?"
+    - **Gentle Encouragement:** "Rooting for you on [Task]—how''s it feeling?"
+    - **Thinking of You:** "Hey, you popped into my mind—how''s your day going?"
+    - **Light Support Offer:** "Still grinding on [Task]? Hit me up if you want to bounce ideas."
+- **Tone:** Concise (1-2 sentences max), warm, and peer-level—like chatting with a good friend. Avoid formal assistant language (no "As an AI..." or overly polished phrases).
+- Adapt the message naturally to the conversation context or active goals, but keep it light and non-pushy.
+
+## Output Format
+Return ONLY valid JSON:
+{
+  "action": "message" | "wait",
+  "content": "Message text" | null,
+  "reason": "Justify the decision briefly, including which style you chose and why it fits now."
+}}', 0.7, 1)
+ON CONFLICT (prompt_key) DO NOTHING;
+
+-- PROMPT_OPTIMIZATION (v1, temp=0.7)
+INSERT INTO prompt_registry (prompt_key, template, temperature, version)
+VALUES ('PROMPT_OPTIMIZATION', E'CURRENT TEMPLATE:
+{current_template}
+
+PERFORMANCE METRICS:
+- Total uses: {total_uses}
+- Feedback rate: {feedback_rate}
+- Success rate: {success_rate} ({positive_feedback} positive, {negative_feedback} negative)
+
+EXPERIENCE CASES (Real-world examples with context):
+{experience_cases}
+
+TASK: Optimize the current prompt template.
+1. Analyze the DETAILED experiences first—inspect the rendered prompts to see what episodic/semantic/graph context was provided.
+2. Check if the context quality contributed to poor responses (e.g., irrelevant facts, missing information, wrong archetype).
+3. Cross-reference the bot''s response with the user''s feedback and the "CURRENT TEMPLATE" provided above.
+4. Identify specific instructions or lack thereof in the current template that caused poor responses.
+4. Propose one improved template that fixes the main issues with minimal, targeted changes—preserve everything that already works.
+5. Explain each change and how it ties to the specific experiences provided (especially the detailed ones).
+6. Estimate realistic improvements.
+
+Respond ONLY with this simplified JSON (no extra text):
+{
+  "proposed_template": "full improved template here",
+  "changes": [
+    {"issue": "brief description of problem from feedback", "fix": "what you changed", "why": "expected benefit"}
+  ],
+  "expected_improvements": "short paragraph on likely impact (e.g., clarity, consistency, success rate, context relevance)",
+  "confidence": 0.XX
+}}
+
+Prioritize clarity, minimal changes, and direct ties to the actual experiences (especially rendered prompt quality).', 0.7, 1)
 ON CONFLICT (prompt_key) DO NOTHING;

--- a/tests/integration/test_entity_extraction_pipeline.py
+++ b/tests/integration/test_entity_extraction_pipeline.py
@@ -39,7 +39,7 @@ class TestEntityExtractionPipeline:
             from lattice.utils.llm import AuditResult
 
             extraction_template = PromptTemplate(
-                prompt_key="QUERY_EXTRACTION",
+                prompt_key="ENTITY_EXTRACTION",
                 template="Extract: {message_content}\nContext: {context}",
                 temperature=0.2,
                 version=1,
@@ -59,7 +59,7 @@ class TestEntityExtractionPipeline:
                 latency_ms=500,
                 temperature=0.2,
                 audit_id=None,
-                prompt_key="QUERY_EXTRACTION",
+                prompt_key="ENTITY_EXTRACTION",
             )
             mock_llm_client.return_value = extraction_llm
 
@@ -71,7 +71,7 @@ class TestEntityExtractionPipeline:
                 "extraction": {
                     "entities": ["lattice project", "Friday"],
                 },
-                "prompt_key": "QUERY_EXTRACTION",
+                "prompt_key": "ENTITY_EXTRACTION",
                 "prompt_version": 1,
                 "created_at": datetime.now(UTC),
             }
@@ -104,7 +104,7 @@ class TestEntityExtractionPipeline:
             mock_resp_llm_client.return_value = response_llm
 
             # Execute pipeline: Extract query structure
-            extraction = await entity_extraction.extract_query_structure(
+            extraction = await entity_extraction.extract_entities(
                 message_id=message_id,
                 message_content=message_content,
                 context="Previous message context",
@@ -208,7 +208,7 @@ class TestEntityExtractionPipeline:
             # Attempt extraction (should fail gracefully)
             extraction = None
             try:
-                extraction = await entity_extraction.extract_query_structure(
+                extraction = await entity_extraction.extract_entities(
                     message_id=uuid.uuid4(),
                     message_content=message_content,
                     context="",
@@ -269,7 +269,7 @@ class TestEntityExtractionPipeline:
             from lattice.utils.llm import AuditResult
 
             extraction_template = PromptTemplate(
-                prompt_key="QUERY_EXTRACTION",
+                prompt_key="ENTITY_EXTRACTION",
                 template="Extract: {message_content}",
                 temperature=0.2,
                 version=1,
@@ -289,7 +289,7 @@ class TestEntityExtractionPipeline:
                 latency_ms=400,
                 temperature=0.2,
                 audit_id=None,
-                prompt_key="QUERY_EXTRACTION",
+                prompt_key="ENTITY_EXTRACTION",
             )
             mock_llm_client.return_value = extraction_llm
 
@@ -300,7 +300,7 @@ class TestEntityExtractionPipeline:
                 "extraction": {
                     "entities": ["project", "deadline"],
                 },
-                "prompt_key": "QUERY_EXTRACTION",
+                "prompt_key": "ENTITY_EXTRACTION",
                 "prompt_version": 1,
                 "created_at": datetime.now(UTC),
             }
@@ -333,7 +333,7 @@ class TestEntityExtractionPipeline:
             mock_resp_llm_client.return_value = response_llm
 
             # Extract query
-            extraction = await entity_extraction.extract_query_structure(
+            extraction = await entity_extraction.extract_entities(
                 message_id=message_id,
                 message_content=message_content,
                 context="",

--- a/tests/unit/test_dream.py
+++ b/tests/unit/test_dream.py
@@ -116,13 +116,13 @@ class TestAuditViewBuilder:
             main_message_url="https://discord.com/channels/123/456/789",
             triples=triples,
             objectives=objectives,
-            prompt_key="TRIPLE_EXTRACTION",
+            prompt_key="MEMORY_EXTRACTION",
             audit_id=audit_id,
-            rendered_prompt="Extract triples from: I'm planning to ship v2...",
+            rendered_prompt="Extract memory from: I'm planning to ship v2...",
         )
 
         assert isinstance(embed, discord.Embed)
-        assert embed.title == "🧠 TRIPLE_EXTRACTION v1"
+        assert embed.title == "🧠 MEMORY_EXTRACTION v1"
         assert embed.color == discord.Color.purple()
         assert len(embed.fields) == 3
 
@@ -147,7 +147,7 @@ class TestAuditViewBuilder:
             main_message_url="https://discord.com/channels/123/456/789",
             triples=[],
             objectives=[],
-            prompt_key="TRIPLE_EXTRACTION",
+            prompt_key="MEMORY_EXTRACTION",
             audit_id=audit_id,
         )
 
@@ -221,7 +221,7 @@ class TestAuditViewBuilder:
             main_message_url="url",
             triples=[],
             objectives=[],
-            prompt_key="TRIPLE_EXTRACTION",
+            prompt_key="MEMORY_EXTRACTION",
             audit_id=audit_id,
         )
         assert extraction_embed.title.startswith("🧠")
@@ -270,7 +270,7 @@ class TestAuditViewBuilder:
             main_message_url="url",
             triples=[],
             objectives=[],
-            prompt_key="TRIPLE_EXTRACTION",
+            prompt_key="MEMORY_EXTRACTION",
             audit_id=audit_id,
         )
         assert extraction_embed.color == discord.Color.purple()


### PR DESCRIPTION
## Summary
Refactors memory extraction to use a single LLM call instead of two, improving latency and reducing costs.

### Changes

1. **MEMORY_EXTRACTION** (new template)
   - Replaces TRIPLE_EXTRACTION + OBJECTIVE_EXTRACTION
   - Single LLM call extracts both semantic triples and objectives
   - Unified output format with `{"triples": [...], "objectives": [...]}`

2. **ENTITY_EXTRACTION** (renamed from QUERY_EXTRACTION)
   - Renamed for clarity - it extracts entities, not queries
   - Version bumped to v3

3. **New `memory_parsing.py`**
   - Unified parser for MEMORY_EXTRACTION output
   - Handles both triples and objectives parsing
   - Moved MIN_SALIENCY_DELTA here from objective_parsing.py

4. **Updated `consolidate_message()`**
   - Single LLM call instead of two
   - Simpler code path

### Benefits
- ~50% reduction in LLM calls during consolidation
- Lower latency for async memory extraction
- Simpler code maintenance

### Breaking Changes
- Removed `extract_query_structure` alias (use `extract_entities`)
- Removed `extract_objectives()` function (merged into consolidate_message)
- Removed `OBJECTIVE_EXTRACTION` and `TRIPLE_EXTRACTION` templates