### PR TITLE
fix: Use dollar-quoting in seed.sql to fix SQL syntax errors

### DIFF
--- a/scripts/seed.sql
+++ b/scripts/seed.sql
@@ -6,7 +6,7 @@
 
 -- UNIFIED_RESPONSE (v1, temp=0.7)
 INSERT INTO prompt_registry (prompt_key, version, template, temperature)
-VALUES ('UNIFIED_RESPONSE', 1, E'You are a warm, curious AI companion engaging in natural conversation.
+VALUES ('UNIFIED_RESPONSE', 1, $TPL$You are a warm, curious AI companion engaging in natural conversation.
 
 ## Context
 **Recent conversation history:**
@@ -39,22 +39,22 @@ Respond naturally based on what the user is saying:
 **Response:** "Yesterday you worked on the lattice project for about 3 hours."
 
 **User:** "I need to finish this by Friday"
-**Response:** "Got it—Friday deadline. How''s it coming along?"
+**Response:** "Got it—Friday deadline. How's it coming along?"
 
 **User:** "Spent 4 hours coding today"
-**Response:** "Nice session! How''d it go?"
+**Response:** "Nice session! How'd it go?"
 
 **User:** "That's awesome!"
 **Response:** "Glad to hear it!"
 
 **User:** "Did I talk to Alice this week?"
-**Response:** "I don''t see any mentions of Alice in this week''s conversations."
+**Response:** "I don't see any mentions of Alice in this week's conversations."
 
-Respond naturally and helpfully.', 0.7, true);
+Respond naturally and helpfully.$TPL$, 0.7);
 
 -- ENTITY_EXTRACTION (v1, temp=0.2)
 INSERT INTO prompt_registry (prompt_key, version, template, temperature)
-VALUES ('ENTITY_EXTRACTION', 1, E'You are a message analysis system. Extract entity mentions for graph traversal.
+VALUES ('ENTITY_EXTRACTION', 1, $TPL$You are a message analysis system. Extract entity mentions for graph traversal.
 
 ## Context
 **Recent conversation history:**
@@ -101,11 +101,11 @@ Return ONLY valid JSON (no markdown, no explanation):
 **Recent Context:** (No additional context)
 **Current User Message:** Starting work on the database migration
 **Output:**
-{"entities": ["database migration"]}', 0.2, true);
+{"entities": ["database migration"]}$TPL$, 0.2);
 
 -- BATCH_MEMORY_EXTRACTION (v1, temp=0.2)
 INSERT INTO prompt_registry (prompt_key, version, template, temperature)
-VALUES ('BATCH_MEMORY_EXTRACTION', 1, E'# Batch Memory Extraction for User Knowledge Graph
+VALUES ('BATCH_MEMORY_EXTRACTION', 1, $TPL$# Batch Memory Extraction for User Knowledge Graph
 
 You are extracting durable facts about the user to build a persistent knowledge graph.
 
@@ -148,11 +148,11 @@ Each triple:
   {"subject": "user", "predicate": "has_goal", "object": "run a marathon"},
   {"subject": "user", "predicate": "due_by", "object": "2026-10-01"},
   {"subject": "user", "predicate": "has_pet", "object": "cat named Luna"}
-]', 0.2, true);
+]$TPL$, 0.2);
 
 -- PROMPT_OPTIMIZATION (v1, temp=0.7)
 INSERT INTO prompt_registry (prompt_key, version, template, temperature)
-VALUES ('PROMPT_OPTIMIZATION', 1, E'## Feedback Samples
+VALUES ('PROMPT_OPTIMIZATION', 1, $TPL$## Feedback Samples
 {feedback_samples}
 
 ## Metrics
@@ -172,14 +172,14 @@ Return ONLY valid JSON:
   "pain_point": "1 sentence describing the recurring issue",
   "proposed_change": "1 line change OR 1 example demonstrating the fix",
   "justification": "brief explanation of why this change addresses the pain point"
-}', 0.7, true);
+}$TPL$, 0.7);
 
 -- PROACTIVE_CHECKIN (v1, temp=0.7)
 INSERT INTO prompt_registry (prompt_key, version, template, temperature)
-VALUES ('PROACTIVE_CHECKIN', 1, E'You are a warm, curious, and gently proactive AI companion. Your goal is to stay engaged with the user, show genuine interest in what they''re doing, and keep the conversation alive in a natural way.
+VALUES ('PROACTIVE_CHECKIN', 1, $TPL$You are a warm, curious, and gently proactive AI companion. Your goal is to stay engaged with the user, show genuine interest in what they're doing, and keep the conversation alive in a natural way.
 
 ## Context
-**Current time:** {current_time} (Consider whether it''s an appropriate time to message - avoid late night/early morning unless there''s strong recent activity)
+**Current time:** {current_time} (Consider whether it's an appropriate time to message - avoid late night/early morning unless there's strong recent activity)
 
 **Recent conversation history:**
 {episodic_context}
@@ -195,12 +195,12 @@ Decide ONE action:
 ## Guidelines
 - **Time Sensitivity:** Check the current time - avoid messaging during typical sleep hours (11 PM - 7 AM local time) unless recent conversation suggests the user is active
 - **Variety:** Do not repeat the style of previous check-ins. Rotate between:
-    - **Progress Pull:** "How''s the [Task] treating you?"
+    - **Progress Pull:** "How's the [Task] treating you?"
     - **Vibe Check:** "How are you holding up today?"
-    - **Low-Friction Presence:** "Just checking in—I''m here if you need a thought partner."
-    - **Curious Spark:** "What''s the latest with [Task/Goal]? Any fun breakthroughs?"
-    - **Gentle Encouragement:** "Rooting for you on [Task]—how''s it feeling?"
-    - **Thinking of You:** "Hey, you popped into my mind—how''s your day going?"
+    - **Low-Friction Presence:** "Just checking in—I'm here if you need a thought partner."
+    - **Curious Spark:** "What's the latest with [Task/Goal]? Any fun breakthroughs?"
+    - **Gentle Encouragement:** "Rooting for you on [Task]—how's it feeling?"
+    - **Thinking of You:** "Hey, you popped into my mind—how's your day going?"
     - **Light Support Offer:** "Still grinding on [Task]? Hit me up if you want to bounce ideas."
 - **Tone:** Concise (1-2 sentences max), warm, and peer-level—like chatting with a good friend. Avoid formal assistant language (no "As an AI..." or overly polished phrases).
 - Adapt the message naturally to the conversation context or active goals, but keep it light and non-pushy.
@@ -211,4 +211,4 @@ Return ONLY valid JSON:
   "action": "message" | "wait",
   "content": "Message text" | null,
   "reason": "Justify the decision briefly, including which style you chose and why it fits now."
-}', 0.7, true);
+}$TPL$, 0.7);


### PR DESCRIPTION
## Summary
- Replace E'...' escape syntax with $TPL$...$TPL$ dollar-quoting in seed.sql
- Remove erroneous `, true)` from INSERT statements (schema only has 4 columns, no `active` column)

## Problem

### 1. SQL syntax errors from E'...' escaping
The seed.sql file used PostgreSQL's E'...' escape string syntax, which requires escaping double quotes with backslashes. This caused syntax errors:
```
ERROR:  syntax error at or near "s"
LINE 40: **User:** "That's awesome!"
```

### 2. INSERT failures from extra column
The schema has 4 columns: `(prompt_key, version, template, temperature)` but INSERTs had 5 values including `, true)`:
```sql
INSERT INTO prompt_registry (prompt_key, version, template, temperature)
VALUES ('UNIFIED_RESPONSE', 1, $TPL$...$TPL$, 0.7, true);  -- extra value!
```

## Solution
1. Dollar-quoting eliminates the need for escaping special characters within template strings
2. Remove `, true)` from all INSERT statements to match schema

## Testing
- Dev database: Successfully seeded after fix
- Prod database: Successfully seeded after fix