### PR TITLE
Fix: restore CONTEXT_STRATEGY_WINDOW_SIZE to 10

### DIFF
--- a/lattice/core/constants.py
+++ b/lattice/core/constants.py
@@ -9,7 +9,7 @@ makes it easier to tune the system.
 
 # Number of recent messages to analyze for context strategy extraction
 # Used for detecting entities, context flags, and unresolved entities
-CONTEXT_STRATEGY_WINDOW_SIZE = 5
+CONTEXT_STRATEGY_WINDOW_SIZE = 10
 
 # Number of recent messages to include in response generation context
 # Used for UNIFIED_RESPONSE prompt template


### PR DESCRIPTION
Changed from 5 back to 10 to maintain original behavior for context
strategy extraction. Smaller window was too restrictive for detecting
entities and context flags across conversation history.