### PR TITLE
Increase RESPONSE_EPISODIC_LIMIT to 25 for better overlap

### DIFF
--- a/lattice/core/constants.py
+++ b/lattice/core/constants.py
@@ -13,7 +13,8 @@ CONTEXT_STRATEGY_WINDOW_SIZE = 10
 
 # Number of recent messages to include in response generation context
 # Used for UNIFIED_RESPONSE prompt template
-RESPONSE_EPISODIC_LIMIT = 15
+# Must be larger than CONSOLIDATION_BATCH_SIZE to ensure overlap
+RESPONSE_EPISODIC_LIMIT = 25
 
 # Number of messages to trigger memory consolidation batch
 # Used for MEMORY_CONSOLIDATION prompt template


### PR DESCRIPTION
Response window (25) is now larger than consolidation window (18),
ensuring messages being consolidated are still visible in response context.
This prevents context loss between consolidation cycles.

**Rationale:**
- Previous: RESPONSE_EPISODIC_LIMIT = 15, CONSOLIDATION_BATCH_SIZE = 18
- When consolidation ran, only last 15 messages were in response context
- Messages 16-18 got consolidated without being in response
- Could lead to context gaps

**New approach:**
- RESPONSE_EPISODIC_LIMIT = 25, CONSOLIDATION_BATCH_SIZE = 18
- Messages being consolidated (last 18) are always within response context (last 25)
- Ensures continuity and prevents context loss