### PR TITLE
feat: Add typing indicator as response is being generated

### DIFF
--- a/lattice/discord_client/message_handler.py
+++ b/lattice/discord_client/message_handler.py
@@ -232,7 +232,6 @@ class MessageHandler:
             len(message.content) * TYPING_DELAY_MS_PER_CHAR / 1000,
             MAX_TYPING_DELAY_SECONDS,
         )
-        typing_task = None
         typing_task = asyncio.create_task(
             self._delayed_typing(message.channel, typing_delay)
         )


### PR DESCRIPTION
## Related
None

## Summary
Adds a typing indicator that shows after a calculated delay (10ms per character, max 3s) to mimic natural human reading rhythm.

## Changes
- Added `TYPING_DELAY_MS_PER_CHAR` (10ms) and `MAX_TYPING_DELAY_SECONDS` (3s) constants
- Added `_delayed_typing()` method to handle delayed typing indicator
- Modified `handle_message()` to calculate delay based on message length and trigger typing

## Impact
- **Performance**: Negligible (only adds async sleep before showing typing)
- **Architecture**: No breaking changes
- **Testing**: All unit tests pass
- **User Experience**: More engaging experience