### PR TITLE
fix: add packages write permission to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  packages: write
+
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository }}/lattice-bot
   IMAGE_TAG: ${{ github.sha }}


### PR DESCRIPTION
## Related
None

## Summary
Grant GitHub Actions token write permissions for packages to fix Container Registry push errors.

## Changes
- Added `permissions: packages: write` to .github/workflows/deploy.yml
- Enables pushing Docker images to GitHub Container Registry

## Impact
- **Performance**: None
- **Architecture**: None
- **Testing**: None
- **Breaking changes**: None