### PR TITLE
fix: add packages write permission to rollback workflow

### DIFF
--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -8,6 +8,9 @@ on:
         required: true
         default: 'latest'
 
+permissions:
+  packages: write
+
 jobs:
   rollback:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Related
None

## Summary
Grant GitHub Actions token write permissions for packages to match deploy.yml configuration.

## Changes
- Added `permissions: packages: write` to .github/workflows/rollback.yml
- Ensures rollback workflow has same permissions as deploy workflow

## Impact
- **Performance**: None
- **Architecture**: None
- **Testing**: None
- **Breaking changes**: None