### PR TITLE
fix: standardize Dockerfile FROM AS casing for buildx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for optimal image size
-FROM python:3.12-slim as builder
+FROM python:3.12-slim AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Related
None

## Summary
Fix Docker buildx warning about inconsistent keyword casing.

## Changes
- Change 'as' to 'AS' in FROM statement (line 2)
- Matches uppercase FROM keyword convention

## Impact
- **Performance**: None
- **Architecture**: None
- **Testing**: None
- **Breaking changes**: None