### PR TITLE
feat: add OpenRouter model fallback and timeout support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,8 @@ POSTGRES_PORT=5432
 LLM_PROVIDER=openrouter
 OPENROUTER_API_KEY=sk-or-v1-xxxxx
 OPENROUTER_MODEL=nvidia/nemotron-3-nano-30b-a3b:free
+# Comma-separated list for automatic fallback: "primary/model,fallback1,fallback2"
+OPENROUTER_TIMEOUT=30  # Request timeout in seconds
 
 # ============================================================================
 # ENVIRONMENT-SPECIFIC FLAGS

--- a/lattice/utils/config.py
+++ b/lattice/utils/config.py
@@ -44,6 +44,7 @@ class Config:
     llm_provider: str
     openrouter_api_key: str | None
     openrouter_model: str
+    openrouter_timeout: int
     gemini_api_key: str | None
 
     # Application Settings
@@ -71,6 +72,7 @@ class Config:
             openrouter_model=os.getenv(
                 "OPENROUTER_MODEL", "anthropic/claude-3.5-sonnet"
             ),
+            openrouter_timeout=_get_env_int("OPENROUTER_TIMEOUT", 30),
             gemini_api_key=os.getenv("GEMINI_API_KEY"),
             environment=os.getenv("ENVIRONMENT", "production"),
             log_level=os.getenv("LOG_LEVEL", "INFO").upper(),


### PR DESCRIPTION
## Summary
- Add `OPENROUTER_TIMEOUT` config (default 30s) for HTTP request timeout
- Support comma-separated models in `OPENROUTER_MODEL` for automatic fallback
- Fallback models use OpenRouter's `extra_body.models` array with weight 0.5
- Primary model uses weight 1.0 and is also passed as the `model` param
- Add `timeout` parameter to `complete()` method for per-call override

## Changes
- `lattice/utils/config.py`: Add `openrouter_timeout` field
- `lattice/utils/llm_client.py`: Add timeout param, parse comma-separated models, build extra_body for fallbacks
- `.env.example`: Document new config options
- `tests/unit/test_llm.py`: Add 6 new tests for fallback and timeout behavior

## Usage
```bash
# Single model (no fallback)
OPENROUTER_MODEL=anthropic/claude-3.5-sonnet

# Multiple models with automatic fallback
OPENROUTER_MODEL=primary/model,fallback1,fallback2

# Custom timeout (seconds)
OPENROUTER_TIMEOUT=60
```

## Testing
- All 28 LLM tests pass
- MyPy: no issues
- Ruff: all checks pass