### PR TITLE
feat: add OpenRouter model fallback and timeout support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,8 @@ POSTGRES_PORT=5432
 LLM_PROVIDER=openrouter
 OPENROUTER_API_KEY=sk-or-v1-xxxxx
 OPENROUTER_MODEL=nvidia/nemotron-3-nano-30b-a3b:free
+# Comma-separated list for automatic fallback: "primary/model,fallback1,fallback2"
+OPENROUTER_TIMEOUT=30  # Request timeout in seconds
 
 # ============================================================================
 # ENVIRONMENT-SPECIFIC FLAGS

--- a/lattice/utils/config.py
+++ b/lattice/utils/config.py
@@ -44,6 +44,7 @@ class Config:
     llm_provider: str
     openrouter_api_key: str | None
     openrouter_model: str
+    openrouter_timeout: int
     gemini_api_key: str | None
 
     # Application Settings
@@ -71,6 +72,7 @@ class Config:
             openrouter_model=os.getenv(
                 "OPENROUTER_MODEL", "anthropic/claude-3.5-sonnet"
             ),
+            openrouter_timeout=_get_env_int("OPENROUTER_TIMEOUT", 30),
             gemini_api_key=os.getenv("GEMINI_API_KEY"),
             environment=os.getenv("ENVIRONMENT", "production"),
             log_level=os.getenv("LOG_LEVEL", "INFO").upper(),


### PR DESCRIPTION
## Related
Closes #204

## Summary
Add OpenRouter model fallback support via comma-separated models in `OPENROUTER_MODEL` and configurable timeout via `OPENROUTER_TIMEOUT`.

## Changes
- Add `openrouter_timeout` config field (default 30s) in `config.py`
- Add timeout parameter to `complete()` and `_openrouter_complete()` in `llm_client.py`
- Parse comma-separated models for automatic fallback via `extra_body.models`
- Primary model uses weight 1.0, fallbacks use weight 0.5
- Update `.env.example` with documentation for new config options
- Add 6 new tests for fallback models and timeout behavior in `test_llm.py`

## Impact
- Testing: All 28 LLM tests pass
- Performance: HTTP timeout prevents hanging requests
- Architecture: Non-breaking - optional timeout param, backward compatible model format