### PR TITLE
ci: add migration immutability audit

### DIFF
--- a/.github/workflows/migration-immutability.yml
+++ b/.github/workflows/migration-immutability.yml
@@ -1,0 +1,44 @@
+name: Migration Immutability Audit
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/migrations/**'
+
+jobs:
+  audit-migrations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR Branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify No Changes to Existing Migrations
+        run: |
+          BASE_BRANCH="origin/${{ github.base_ref }}"
+
+          echo "Auditing migration changes against $BASE_BRANCH..."
+
+          CHANGED_FILES=$(git diff --name-only $BASE_BRANCH...HEAD -- 'scripts/migrations/' | xargs)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No existing migrations were modified. Proceeding."
+            exit 0
+          fi
+
+          FORBIDDEN_CHANGES=()
+          for FILE in $CHANGED_FILES; do
+            if git ls-tree -r $BASE_BRANCH --name-only | grep -q "^$FILE$"; then
+              FORBIDDEN_CHANGES+=("$FILE")
+            fi
+          done
+
+          if [ ${#FORBIDDEN_CHANGES[@]} -ne 0 ]; then
+            echo "ERROR: The following immutable migrations were modified or renamed:"
+            for FILE in "${FORBIDDEN_CHANGES[@]}"; do
+              echo "  - $FILE"
+            done
+            echo "Directly modifying merged migrations causes schema desync. Create a new version instead."
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,11 @@ pre-commit: ## Run all pre-commit hooks on all files
 check-discord-v2: ## Check that Discord UI components use V2 APIs
 	python scripts/check_discord_v2.py
 
-check-all: lint type-check check-discord-v2 ## Run all quality checks
+check-migrations: ## Check that existing migrations are immutable
+	@echo "Checking migration immutability..."
+	@scripts/check_migrations.sh || exit 1
+
+check-all: lint type-check check-discord-v2 check-migrations ## Run all quality checks
 
 # ============================================================================
 # Application Commands

--- a/scripts/check_migrations.sh
+++ b/scripts/check_migrations.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Auditing migration changes against main..."
+
+CHANGED_FILES=$(git diff --name-only main...HEAD -- 'scripts/migrations/' 2>/dev/null | xargs || true)
+
+if [ -z "$CHANGED_FILES" ]; then
+    echo "No existing migrations were modified. Proceeding."
+    exit 0
+fi
+
+FORBIDDEN_CHANGES=()
+for FILE in $CHANGED_FILES; do
+    if git ls-tree -r main --name-only | grep -q "^$FILE$"; then
+        FORBIDDEN_CHANGES+=("$FILE")
+    fi
+done
+
+if [ ${#FORBIDDEN_CHANGES[@]} -ne 0 ]; then
+    echo "ERROR: The following immutable migrations were modified or renamed:"
+    for FILE in "${FORBIDDEN_CHANGES[@]}"; do
+        echo "  - $FILE"
+    done
+    echo "Directly modifying merged migrations causes schema desync. Create a new version instead."
+    exit 1
+fi
+
+echo "No immutable migration changes detected."


### PR DESCRIPTION
## Related
None

## Summary
Adds CI/CD and local checks to prevent modifications to merged migrations, preventing schema desync issues.

## Changes
- Added `.github/workflows/migration-immutability.yml` workflow for PR path triggers
- Added `scripts/check_migrations.sh` local script using git diff against main
- Added `check-migrations` target to Makefile integrated into `check-all`

## Impact
- Prevents accidental modification of merged migration files
- Enforces migration immutability in both CI and local development
- No performance or breaking changes