### PR TITLE
refactor: Repository Layer Migration Continuation (#169)

### DIFF
--- a/lattice/app.py
+++ b/lattice/app.py
@@ -1,16 +1,20 @@
 import structlog
 
 from lattice.discord_client.bot import LatticeBot
-from lattice.utils.database import DatabasePool
-from lattice.utils.llm import _LLMClient, AuditingLLMClient
-from lattice.utils.config import config
-from lattice.core.context import ChannelContextCache, UserContextCache
 from lattice.memory.context import (
     PostgresCanonicalRepository,
     PostgresContextRepository,
     PostgresMessageRepository,
     PostgresSemanticMemoryRepository,
 )
+from lattice.memory.repositories import (
+    PostgresPromptAuditRepository,
+    PostgresUserFeedbackRepository,
+)
+from lattice.utils.database import DatabasePool
+from lattice.utils.llm import _LLMClient, AuditingLLMClient
+from lattice.utils.config import config
+from lattice.core.context import ChannelContextCache, UserContextCache
 
 
 logger = structlog.get_logger(__name__)
@@ -31,6 +35,8 @@ class LatticeApp:
         self.message_repo = PostgresMessageRepository(db_pool=self.db_pool)
         self.semantic_repo = PostgresSemanticMemoryRepository(db_pool=self.db_pool)
         self.canonical_repo = PostgresCanonicalRepository(db_pool=self.db_pool)
+        self.audit_repo = PostgresPromptAuditRepository(db_pool=self.db_pool)
+        self.feedback_repo = PostgresUserFeedbackRepository(db_pool=self.db_pool)
         self.context_cache = ChannelContextCache(repository=self.context_repo, ttl=10)
         self.user_context_cache = UserContextCache(
             repository=self.context_repo, ttl_minutes=30
@@ -43,6 +49,8 @@ class LatticeApp:
             message_repo=self.message_repo,
             semantic_repo=self.semantic_repo,
             canonical_repo=self.canonical_repo,
+            audit_repo=self.audit_repo,
+            feedback_repo=self.feedback_repo,
         )
 
     async def start(self) -> None:

--- a/lattice/discord_client/bot.py
+++ b/lattice/discord_client/bot.py
@@ -54,6 +54,8 @@ class LatticeBot(commands.Bot):
         message_repo: "MessageRepository",
         semantic_repo: "SemanticMemoryRepository",
         canonical_repo: "CanonicalRepository",
+        audit_repo: Any = None,
+        feedback_repo: Any = None,
     ) -> None:
         intents = discord.Intents.default()
         intents.message_content = True
@@ -66,6 +68,8 @@ class LatticeBot(commands.Bot):
         self.message_repo = message_repo
         self.semantic_repo = semantic_repo
         self.canonical_repo = canonical_repo
+        self.audit_repo = audit_repo
+        self.feedback_repo = feedback_repo
 
         # Initialize the pipeline
         self.pipeline = UnifiedPipeline(
@@ -103,6 +107,7 @@ class LatticeBot(commands.Bot):
             context_cache=self.context_cache,
             user_context_cache=self.user_context_cache,
             message_repo=self.message_repo,
+            canonical_repo=self.canonical_repo,
         )
 
         self._error_manager = ErrorManager(
@@ -178,6 +183,8 @@ class LatticeBot(commands.Bot):
                 dream_channel_id=self.dream_channel_id,
                 db_pool=self.db_pool,
                 llm_client=self.llm_client,
+                prompt_audit_repo=self.audit_repo,
+                user_feedback_repo=self.feedback_repo,
             )
             await self._dreaming_scheduler.start()
 

--- a/lattice/dreaming/proposer.py
+++ b/lattice/dreaming/proposer.py
@@ -158,7 +158,10 @@ def _validate_proposal_fields(data: dict[str, Any]) -> str | None:
 
 
 async def propose_optimization(
-    metrics: "PromptMetrics", db_pool: Any, llm_client: Any
+    metrics: "PromptMetrics",
+    db_pool: Any,
+    llm_client: Any,
+    prompt_audit_repo: Any = None,
 ) -> OptimizationProposal | None:
     """Generate optimization proposal for an underperforming prompt.
 
@@ -166,6 +169,7 @@ async def propose_optimization(
         metrics: Prompt metrics indicating performance issues
         db_pool: Database pool for dependency injection (required)
         llm_client: LLM client for dependency injection (required)
+        prompt_audit_repo: Prompt audit repository
 
     Returns:
         OptimizationProposal if generated, None otherwise
@@ -200,6 +204,7 @@ async def propose_optimization(
         prompt_key=metrics.prompt_key,
         limit=MAX_FEEDBACK_SAMPLES,
         db_pool=db_pool,
+        prompt_audit_repo=prompt_audit_repo,
     )
 
     if not feedback_samples:

--- a/lattice/memory/batch_consolidation.py
+++ b/lattice/memory/batch_consolidation.py
@@ -18,6 +18,8 @@ Legacy support:
     - New code should use should_consolidate() and run_consolidation_batch()
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 import structlog
@@ -39,7 +41,10 @@ from lattice.utils.placeholder_injector import PlaceholderInjector
 
 if TYPE_CHECKING:
     from lattice.utils.database import DatabasePool
-    from lattice.memory.repositories import MessageRepository
+    from lattice.memory.repositories import (
+        CanonicalRepository,
+        MessageRepository,
+    )
 
 
 logger = structlog.get_logger(__name__)
@@ -417,6 +422,7 @@ async def check_and_run_batch(db_pool: Any, message_repo: "MessageRepository") -
 async def run_batch_consolidation(
     db_pool: "DatabasePool",
     message_repo: "MessageRepository",
+    canonical_repo: "CanonicalRepository | None" = None,
     llm_client: Any = None,
     bot: Any = None,
     user_context_cache: Any = None,


### PR DESCRIPTION
## Related
Preparation for Phase 8 of #169

## Summary (Partial Implementation)
This PR adds the infrastructure for repository-based database access but does not fully migrate all components. The analyzer.py and batch_consolidation.py functions now accept repository parameters, but their internal queries still use direct `conn.fetch()` calls.

## Changes
- Add `PromptAuditRepository`, `UserFeedbackRepository`, `PromptRegistryRepository` protocols to `repositories.py`
- Add `PostgresPromptAuditRepository`, `PostgresUserFeedbackRepository`, `PostgresPromptRegistryRepository` implementations
- Update `analyze_prompt_effectiveness()` and `get_feedback_with_context()` to accept repository parameters
- Update `DreamingScheduler` to create and use repositories
- Update `LatticeBot` and `MessageHandler` to pass repositories to downstream components
- Update `batch_consolidation.py` to accept canonical repository parameter
- Update `LatticeApp` to instantiate and wire all repositories via DI

## What Was NOT Changed (Needs Follow-up PR)
The following still have direct DB access (`conn.fetch`, `conn.execute`) that should be migrated:

1. **lattice/dreaming/analyzer.py** - `analyze_prompt_effectiveness()` still uses direct SQL
2. **lattice/memory/batch_consolidation.py** - Functions still use `db_pool.pool` directly
3. **lattice/scheduler/runner.py** - Not modified at all

## Impact
- **Architecture**: Continues migration toward zero direct DB access pattern
- **Testing**: All 463 unit tests pass, all CI checks pass
- **Breaking changes**: None - all repository parameters are optional for backward compatibility
- **Type checking**: mypy passes with no errors