### PR TITLE
fix: chunk long rendered prompts in AuditView details thread

### DIFF
--- a/lattice/discord_client/dream.py
+++ b/lattice/discord_client/dream.py
@@ -11,6 +11,7 @@ from uuid import UUID
 import discord
 import structlog
 
+from lattice.core.response_generator import split_response
 from lattice.memory import prompt_audits, user_feedback
 from lattice.utils.llm_client import GenerationResult
 
@@ -423,7 +424,11 @@ class AuditView(discord.ui.DesignerView):
                 )
                 return
 
-            await thread.send(f"**Rendered Prompt**\n{self.rendered_prompt}")
+            prompt_chunks = split_response(self.rendered_prompt, max_length=1900)
+            for i, chunk in enumerate(prompt_chunks):
+                await thread.send(
+                    f"**Rendered Prompt** ({i + 1}/{len(prompt_chunks)})\n{chunk}"
+                )
 
             if len(self.raw_output) <= 19000:
                 await thread.send(f"**Raw Output**\n{self.raw_output}")


### PR DESCRIPTION
## Related
Closes #246

## Summary
Fixes the AuditView details button failing with a 400 Bad Request error when rendered prompts exceed Discord's 4000 character limit. Long prompts are now chunked before sending to the thread.

## Changes
- Import `split_response` from `lattice.core.response_generator`
- Chunk `rendered_prompt` using existing `split_response()` function in `_make_details_callback()`
- Match the chunking pattern already used for `raw_output` with pagination headers

## Impact
- Performance: No impact
- Architecture: Reuses existing `split_response()` utility
- Testing: Existing audit view tests cover this flow
- Breaking changes: None