### PR TITLE
feat: create audit threads upfront with footer link, remove details button

### DIFF
--- a/lattice/discord_client/audit_mirror.py
+++ b/lattice/discord_client/audit_mirror.py
@@ -87,7 +87,7 @@ class AuditMirror:
         if params.get("main_message_url"):
             metadata.append(f"[LINK]({params['main_message_url']})")
 
-        embed, view = AuditViewBuilder.build_standard_audit(
+        embed, view, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key=prompt_key,
             version=template_version,
             input_text=params.get("input_text", rendered_prompt[:200] + "..."),
@@ -97,6 +97,7 @@ class AuditMirror:
             rendered_prompt=rendered_prompt,
             audit_repo=self.audit_repo,
             feedback_repo=self.feedback_repo,
+            channel=dream_channel,
         )
 
         try:

--- a/lattice/discord_client/dream.py
+++ b/lattice/discord_client/dream.py
@@ -312,16 +312,9 @@ class AuditView(discord.ui.DesignerView):
         self.rendered_prompt = rendered_prompt
         self.raw_output = raw_output
 
-        details_button: Any = discord.ui.Button(
-            emoji="🔍",
-            style=discord.ButtonStyle.secondary,
-            custom_id=f"audit:details:{audit_id}" if audit_id else "audit:details",
-        )
-        details_button.callback = self._make_details_callback()
-
         feedback_button: Any = discord.ui.Button(
             emoji="💬",
-            style=discord.ButtonStyle.primary,
+            style=discord.ButtonStyle.secondary,
             custom_id=f"audit:feedback:{audit_id}" if audit_id else "audit:feedback",
         )
         feedback_button.callback = self._make_feedback_callback()
@@ -345,7 +338,6 @@ class AuditView(discord.ui.DesignerView):
         quick_negative_button.callback = self._make_quick_negative_callback()
 
         action_row: Any = discord.ui.ActionRow(
-            details_button,
             feedback_button,
             quick_positive_button,
             quick_negative_button,
@@ -382,82 +374,6 @@ class AuditView(discord.ui.DesignerView):
             await interaction.followup.send(view=view, ephemeral=True)
 
         return view_prompt_callback
-
-    def _make_details_callback(self) -> Any:
-        """Create details button callback that creates a thread with full content."""
-
-        async def details_callback(interaction: discord.Interaction) -> None:
-            """Handle Details button click - creates thread with full content."""
-            if not self.raw_output or not self.rendered_prompt:
-                await interaction.response.send_message(
-                    "Content not available.",
-                    ephemeral=True,
-                )
-                return
-
-            thread_name = f"Audit: {self.prompt_key or 'unknown'}"[:100]
-
-            if not isinstance(interaction.channel, discord.TextChannel):
-                await interaction.response.send_message(
-                    "Cannot create thread in this channel type.",
-                    ephemeral=True,
-                )
-                return
-
-            channel = interaction.channel
-
-            try:
-                thread = await channel.create_thread(
-                    name=thread_name,
-                    auto_archive_duration=1440,
-                )
-            except discord.Forbidden:
-                logger.warning(
-                    "Permission denied when creating audit thread",
-                    audit_id=str(self.audit_id),
-                )
-                await interaction.response.send_message(
-                    "Cannot create thread: missing permissions.",
-                    ephemeral=True,
-                )
-                return
-            except discord.HTTPException as e:
-                logger.warning(
-                    "Failed to create audit thread",
-                    audit_id=str(self.audit_id),
-                    error=str(e),
-                )
-                await interaction.response.send_message(
-                    "Failed to create thread. Please try again.",
-                    ephemeral=True,
-                )
-                return
-
-            prompt_chunks = split_response(self.rendered_prompt, max_length=1900)
-            for chunk in prompt_chunks:
-                await thread.send(f"**Rendered Prompt**\n{chunk}")
-
-            if len(self.raw_output) <= 19000:
-                await thread.send(f"**Raw Output**\n{self.raw_output}")
-            else:
-                chunks = [
-                    self.raw_output[i : i + 19000]
-                    for i in range(0, len(self.raw_output), 19000)
-                ]
-                for chunk in chunks:
-                    await thread.send(f"**Raw Output**\n{chunk}")
-
-            await interaction.response.send_message(
-                f"🔍 {thread.jump_url}",
-                ephemeral=True,
-            )
-            logger.debug(
-                "Audit details thread created",
-                audit_id=str(self.audit_id),
-                thread_id=thread.id,
-            )
-
-        return details_callback
 
     def _make_feedback_callback(self) -> Any:
         """Create feedback button callback."""
@@ -622,7 +538,7 @@ class AuditViewBuilder:
     }
 
     @staticmethod
-    def build_standard_audit(
+    async def build_standard_audit(
         prompt_key: str,
         version: int,
         input_text: str,
@@ -635,7 +551,8 @@ class AuditViewBuilder:
         result: GenerationResult | None = None,
         message_id: int | None = None,
         warnings: list[str] | None = None,
-    ) -> tuple[discord.Embed, AuditView]:
+        channel: discord.TextChannel | None = None,
+    ) -> tuple[discord.Embed, AuditView, str | None]:
         """Build a unified audit message for any LLM call.
 
         Args:
@@ -650,9 +567,10 @@ class AuditViewBuilder:
             feedback_repo: Feedback repository for dependency injection
             result: Optional full result for rich rendering
             message_id: Optional main Discord message ID for feedback
+            channel: Optional channel to create details thread
 
         Returns:
-            Tuple of (embed, view) for the audit message
+            Tuple of (embed, view, thread_url)
         """
         emoji, color = AuditViewBuilder._STYLE_MAP.get(
             prompt_key, ("🤖", discord.Color.default())
@@ -663,6 +581,35 @@ class AuditViewBuilder:
             title=f"{title_prefix}{emoji} {prompt_key} v{version}",
             color=color,
         )
+
+        thread_url: str | None = None
+        if channel and rendered_prompt:
+            thread_name = f"Audit: {prompt_key or 'unknown'}"[:100]
+            try:
+                thread = await channel.create_thread(
+                    name=thread_name,
+                    auto_archive_duration=1440,
+                )
+                thread_url = thread.jump_url
+
+                prompt_chunks = split_response(rendered_prompt, max_length=1900)
+                for chunk in prompt_chunks:
+                    await thread.send(f"**Rendered Prompt**\n{chunk}")
+
+                raw_output = result.content if result else output_text
+                if len(raw_output) <= 19000:
+                    await thread.send(f"**Raw Output**\n{raw_output}")
+                else:
+                    chunks = [
+                        raw_output[i : i + 19000]
+                        for i in range(0, len(raw_output), 19000)
+                    ]
+                    for chunk in chunks:
+                        await thread.send(f"**Raw Output**\n{chunk}")
+            except discord.Forbidden:
+                logger.warning("Permission denied when creating audit thread")
+            except discord.HTTPException as e:
+                logger.warning("Failed to create audit thread", error=str(e))
 
         embed.add_field(
             name="📥",
@@ -719,7 +666,10 @@ class AuditViewBuilder:
             raw_output=result.content if result else output_text,
         )
 
-        return embed, view
+        if thread_url:
+            embed.set_footer(text=f"[View Full Details]({thread_url})")
+
+        return embed, view, thread_url
 
     @staticmethod
     def format_memories(memories: list[dict[str, Any]]) -> str:

--- a/lattice/discord_client/error_handlers.py
+++ b/lattice/discord_client/error_handlers.py
@@ -68,7 +68,7 @@ async def notify_parse_error_to_dream(
     rendered_prompt = context.get("rendered_prompt", "")
 
     try:
-        embed, view = AuditViewBuilder.build_standard_audit(
+        embed, view, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key=error.prompt_key or "UNKNOWN",
             version=1,
             input_text=f"[{parser_type.upper()}] Parse failed",
@@ -78,6 +78,7 @@ async def notify_parse_error_to_dream(
             rendered_prompt=rendered_prompt,
             audit_repo=bot.audit_repo,
             feedback_repo=bot.feedback_repo,
+            channel=dream_channel,
         )
 
         embed.description = f"❌ **Parse Error**: {error.parse_error}"

--- a/lattice/utils/auditing_middleware.py
+++ b/lattice/utils/auditing_middleware.py
@@ -244,7 +244,8 @@ class AuditingLLMClient:
                     )
 
                     try:
-                        embed, view = AuditViewBuilder.build_standard_audit(
+                        channel = bot.get_channel(effective_dream_channel_id)
+                        embed, view, _ = await AuditViewBuilder.build_standard_audit(
                             prompt_key=prompt_key or "UNKNOWN",
                             version=template_version or 1,
                             input_text=params.get("input_text", prompt[:200] + "..."),
@@ -257,9 +258,9 @@ class AuditingLLMClient:
                             result=result,
                             message_id=main_discord_message_id,
                             warnings=warnings,
+                            channel=channel,
                         )
 
-                        channel = bot.get_channel(effective_dream_channel_id)
                         if channel:
                             await channel.send(embed=embed, view=view)
                             bot.add_view(view)

--- a/tests/unit/test_dream.py
+++ b/tests/unit/test_dream.py
@@ -25,7 +25,7 @@ class TestAuditViewBuilder:
     ) -> None:
         """Test building a reactive audit embed."""
         audit_id = uuid4()
-        embed, _ = AuditViewBuilder.build_standard_audit(
+        embed, _, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key="UNIFIED_RESPONSE",
             version=3,
             input_text="I'm planning to ship v2 by end of month.",
@@ -59,7 +59,7 @@ class TestAuditViewBuilder:
     ) -> None:
         """Test standard audit without cost info."""
         audit_id = uuid4()
-        embed, _ = AuditViewBuilder.build_standard_audit(
+        embed, _, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key="UNIFIED_RESPONSE",
             version=1,
             input_text="Hello!",
@@ -78,7 +78,7 @@ class TestAuditViewBuilder:
     ) -> None:
         """Test building a proactive audit embed."""
         audit_id = uuid4()
-        embed, _ = AuditViewBuilder.build_standard_audit(
+        embed, _, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key="PROACTIVE_CHECKIN",
             version=1,
             input_text="User set deadline 3 days ago. No progress updates in 48h.",
@@ -111,7 +111,7 @@ class TestAuditViewBuilder:
             },
         ]
 
-        embed, _ = AuditViewBuilder.build_standard_audit(
+        embed, _, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key="MEMORY_CONSOLIDATION",
             version=1,
             input_text="I'm planning to ship v2 by end of month.",
@@ -131,7 +131,7 @@ class TestAuditViewBuilder:
     ) -> None:
         """Test extraction audit with no memories."""
         audit_id = uuid4()
-        embed, _ = AuditViewBuilder.build_standard_audit(
+        embed, _, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key="MEMORY_CONSOLIDATION",
             version=1,
             input_text="Hello!",
@@ -150,7 +150,7 @@ class TestAuditViewBuilder:
     ) -> None:
         """Test building a reasoning audit embed."""
         audit_id = uuid4()
-        embed, _ = AuditViewBuilder.build_standard_audit(
+        embed, _, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key="PROACTIVE_CHECKIN",
             version=1,
             input_text="deadline: 3 days, no progress updates, user prefers check-ins",
@@ -170,7 +170,7 @@ class TestAuditViewBuilder:
         """Test that correct emojis are used for different template types."""
         audit_id = uuid4()
 
-        reactive_embed, _ = AuditViewBuilder.build_standard_audit(
+        reactive_embed, _, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key="UNIFIED_RESPONSE",
             version=1,
             input_text="test",
@@ -184,7 +184,7 @@ class TestAuditViewBuilder:
         assert reactive_embed.title is not None
         assert reactive_embed.title.startswith("💬")
 
-        proactive_embed, _ = AuditViewBuilder.build_standard_audit(
+        proactive_embed, _, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key="PROACTIVE_CHECKIN",
             version=1,
             input_text="test",
@@ -198,7 +198,7 @@ class TestAuditViewBuilder:
         assert proactive_embed.title is not None
         assert proactive_embed.title.startswith("🌟")
 
-        extraction_embed, _ = AuditViewBuilder.build_standard_audit(
+        extraction_embed, _, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key="MEMORY_CONSOLIDATION",
             version=1,
             input_text="test",
@@ -219,7 +219,7 @@ class TestAuditViewBuilder:
         """Test that correct colors are used for different template types."""
         audit_id = uuid4()
 
-        reactive_embed, _ = AuditViewBuilder.build_standard_audit(
+        reactive_embed, _, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key="UNIFIED_RESPONSE",
             version=1,
             input_text="test",
@@ -232,7 +232,7 @@ class TestAuditViewBuilder:
         )
         assert reactive_embed.color == discord.Color.blurple()
 
-        proactive_embed, _ = AuditViewBuilder.build_standard_audit(
+        proactive_embed, _, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key="PROACTIVE_CHECKIN",
             version=1,
             input_text="test",
@@ -245,7 +245,7 @@ class TestAuditViewBuilder:
         )
         assert proactive_embed.color == discord.Color.gold()
 
-        extraction_embed, _ = AuditViewBuilder.build_standard_audit(
+        extraction_embed, _, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key="MEMORY_CONSOLIDATION",
             version=1,
             input_text="test",
@@ -266,7 +266,7 @@ class TestAuditViewBuilder:
         audit_id = uuid4()
         long_message = "x" * 2000
 
-        embed, _ = AuditViewBuilder.build_standard_audit(
+        embed, _, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key="UNIFIED_RESPONSE",
             version=1,
             input_text=long_message,
@@ -287,7 +287,7 @@ class TestAuditViewBuilder:
         """Test that warnings are displayed in embed with warning indicator."""
         audit_id = uuid4()
 
-        embed, _ = AuditViewBuilder.build_standard_audit(
+        embed, _, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key="MEMORY_CONSOLIDATION",
             version=1,
             input_text="test input",
@@ -315,7 +315,7 @@ class TestAuditViewBuilder:
         """Test that no warning indicator when no warnings."""
         audit_id = uuid4()
 
-        embed, _ = AuditViewBuilder.build_standard_audit(
+        embed, _, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key="CONTEXTUAL_NUDGE",
             version=1,
             input_text="test input",
@@ -335,7 +335,7 @@ class TestAuditViewBuilder:
     ) -> None:
         """Test building an audit embed without a Discord message ID."""
         audit_id = uuid4()
-        embed, view = AuditViewBuilder.build_standard_audit(
+        embed, view, _ = await AuditViewBuilder.build_standard_audit(
             prompt_key="CONTEXTUAL_NUDGE",
             version=1,
             input_text="Deterministic contextual nudge",
@@ -576,261 +576,6 @@ class TestAuditViewCustomIds:
         custom_ids = [button.custom_id for button in buttons]
 
         # Should use fallback custom_ids without audit_id suffix
-        assert "audit:details" in custom_ids
         assert "audit:feedback" in custom_ids
         assert "audit:quick_positive" in custom_ids
         assert "audit:quick_negative" in custom_ids
-
-
-class TestAuditViewCallbacks:
-    """Integration tests for AuditView button callbacks."""
-
-    @pytest.fixture
-    def mock_audit_repo(self) -> AsyncMock:
-        return AsyncMock()
-
-    @pytest.fixture
-    def mock_feedback_repo(self) -> AsyncMock:
-        return AsyncMock()
-
-    @pytest.mark.asyncio
-    async def test_details_callback_executes(
-        self, mock_audit_repo: AsyncMock, mock_feedback_repo: AsyncMock
-    ) -> None:
-        """Test that details callback creates thread correctly."""
-        audit_id = uuid4()
-        view = AuditView(
-            audit_repo=mock_audit_repo,
-            feedback_repo=mock_feedback_repo,
-            audit_id=audit_id,
-            message_id=12345,
-            prompt_key="TEST_PROMPT",
-            version=1,
-            rendered_prompt="This is test prompt content",
-            raw_output="This is raw output content",
-        )
-
-        mock_interaction = AsyncMock(spec=discord.Interaction)
-        mock_channel = AsyncMock(spec=discord.TextChannel)
-        mock_channel.create_thread = AsyncMock()
-        mock_thread = AsyncMock()
-        mock_thread.jump_url = "https://discord.com/threads/123/456"
-        mock_channel.create_thread.return_value = mock_thread
-        mock_interaction.channel = mock_channel
-        mock_interaction.response = AsyncMock()
-        mock_interaction.response.send_message = AsyncMock()
-
-        callback = view._make_details_callback()
-        await callback(mock_interaction)
-
-        mock_channel.create_thread.assert_called_once()
-        mock_interaction.response.send_message.assert_called_once()
-        assert "🔍" in mock_interaction.response.send_message.call_args[0][0]
-
-    @pytest.mark.asyncio
-    async def test_details_callback_handles_empty_content(
-        self, mock_audit_repo: AsyncMock, mock_feedback_repo: AsyncMock
-    ) -> None:
-        """Test that details callback handles empty content gracefully."""
-        audit_id = uuid4()
-        view = AuditView(
-            audit_repo=mock_audit_repo,
-            feedback_repo=mock_feedback_repo,
-            audit_id=audit_id,
-            message_id=12345,
-            prompt_key="TEST_PROMPT",
-            version=1,
-            rendered_prompt=None,
-            raw_output="test output",
-        )
-
-        mock_interaction = AsyncMock(spec=discord.Interaction)
-        mock_interaction.response = AsyncMock()
-        mock_interaction.response.send_message = AsyncMock()
-
-        callback = view._make_details_callback()
-        await callback(mock_interaction)
-
-        mock_interaction.response.send_message.assert_called_once()
-        assert "not available" in mock_interaction.response.send_message.call_args[0][0]
-        assert mock_interaction.response.send_message.call_args[1]["ephemeral"] is True
-
-    @pytest.mark.asyncio
-    async def test_details_callback_handles_forbidden_error(
-        self, mock_audit_repo: AsyncMock, mock_feedback_repo: AsyncMock
-    ) -> None:
-        """Test that details callback handles Forbidden error gracefully."""
-        audit_id = uuid4()
-        view = AuditView(
-            audit_repo=mock_audit_repo,
-            feedback_repo=mock_feedback_repo,
-            audit_id=audit_id,
-            message_id=12345,
-            prompt_key="TEST_PROMPT",
-            version=1,
-            rendered_prompt="test prompt",
-            raw_output="test output",
-        )
-
-        mock_interaction = AsyncMock(spec=discord.Interaction)
-        mock_channel = AsyncMock(spec=discord.TextChannel)
-        mock_channel.create_thread = AsyncMock(
-            side_effect=discord.Forbidden(
-                response=AsyncMock(status=403),
-                message="Missing Permissions",
-            )
-        )
-        mock_interaction.channel = mock_channel
-        mock_interaction.response = AsyncMock()
-        mock_interaction.response.send_message = AsyncMock()
-
-        callback = view._make_details_callback()
-        await callback(mock_interaction)
-
-        mock_interaction.response.send_message.assert_called_once()
-        assert (
-            "missing permissions"
-            in mock_interaction.response.send_message.call_args[0][0].lower()
-        )
-
-    @pytest.mark.asyncio
-    async def test_details_callback_handles_http_exception(
-        self, mock_audit_repo: AsyncMock, mock_feedback_repo: AsyncMock
-    ) -> None:
-        """Test that details callback handles HTTPException gracefully."""
-        audit_id = uuid4()
-        view = AuditView(
-            audit_repo=mock_audit_repo,
-            feedback_repo=mock_feedback_repo,
-            audit_id=audit_id,
-            message_id=12345,
-            prompt_key="TEST_PROMPT",
-            version=1,
-            rendered_prompt="test prompt",
-            raw_output="test output",
-        )
-
-        mock_interaction = AsyncMock(spec=discord.Interaction)
-        mock_channel = AsyncMock(spec=discord.TextChannel)
-        mock_channel.create_thread = AsyncMock(
-            side_effect=discord.HTTPException(
-                response=AsyncMock(status=500),
-                message="Internal Server Error",
-            )
-        )
-        mock_interaction.channel = mock_channel
-        mock_interaction.response = AsyncMock()
-        mock_interaction.response.send_message = AsyncMock()
-
-        callback = view._make_details_callback()
-        await callback(mock_interaction)
-
-        mock_interaction.response.send_message.assert_called_once()
-        assert (
-            "Failed to create thread"
-            in mock_interaction.response.send_message.call_args[0][0]
-        )
-
-    @pytest.mark.asyncio
-    async def test_details_callback_handles_invalid_channel_type(
-        self, mock_audit_repo: AsyncMock, mock_feedback_repo: AsyncMock
-    ) -> None:
-        """Test that details callback handles non-TextChannel gracefully."""
-        audit_id = uuid4()
-        view = AuditView(
-            audit_repo=mock_audit_repo,
-            feedback_repo=mock_feedback_repo,
-            audit_id=audit_id,
-            message_id=12345,
-            prompt_key="TEST_PROMPT",
-            version=1,
-            rendered_prompt="test prompt",
-            raw_output="test output",
-        )
-
-        mock_interaction = AsyncMock(spec=discord.Interaction)
-        mock_interaction.channel = None
-        mock_interaction.response = AsyncMock()
-        mock_interaction.response.send_message = AsyncMock()
-
-        callback = view._make_details_callback()
-        await callback(mock_interaction)
-
-        mock_interaction.response.send_message.assert_called_once()
-        assert (
-            "channel type"
-            in mock_interaction.response.send_message.call_args[0][0].lower()
-        )
-
-    @pytest.mark.asyncio
-    async def test_details_callback_splits_large_output(
-        self, mock_audit_repo: AsyncMock, mock_feedback_repo: AsyncMock
-    ) -> None:
-        """Test that details callback splits large raw output into chunks."""
-        audit_id = uuid4()
-        large_output = "x" * 40000
-        view = AuditView(
-            audit_repo=mock_audit_repo,
-            feedback_repo=mock_feedback_repo,
-            audit_id=audit_id,
-            message_id=12345,
-            prompt_key="TEST_PROMPT",
-            version=1,
-            rendered_prompt="test prompt",
-            raw_output=large_output,
-        )
-
-        mock_interaction = AsyncMock(spec=discord.Interaction)
-        mock_channel = AsyncMock(spec=discord.TextChannel)
-        mock_channel.create_thread = AsyncMock()
-        mock_thread = AsyncMock()
-        mock_thread.jump_url = "https://discord.com/threads/123/456"
-        mock_thread.send = AsyncMock()
-        mock_channel.create_thread.return_value = mock_thread
-        mock_interaction.channel = mock_channel
-        mock_interaction.response = AsyncMock()
-        mock_interaction.response.send_message = AsyncMock()
-
-        callback = view._make_details_callback()
-        await callback(mock_interaction)
-
-        mock_channel.create_thread.assert_called_once()
-        # 1 for prompt + 3 for raw output chunks (40000 / 19000 = 2.1 -> 3 chunks)
-        assert mock_thread.send.call_count == 4
-
-    @pytest.mark.asyncio
-    async def test_details_callback_thread_name_truncated(
-        self, mock_audit_repo: AsyncMock, mock_feedback_repo: AsyncMock
-    ) -> None:
-        """Test that thread name is truncated to 100 characters."""
-        audit_id = uuid4()
-        view = AuditView(
-            audit_repo=mock_audit_repo,
-            feedback_repo=mock_feedback_repo,
-            audit_id=audit_id,
-            message_id=12345,
-            prompt_key="A" * 200,
-            version=1,
-            rendered_prompt="test prompt",
-            raw_output="test output",
-        )
-
-        mock_interaction = AsyncMock(spec=discord.Interaction)
-        mock_channel = AsyncMock(spec=discord.TextChannel)
-        mock_channel.create_thread = AsyncMock()
-        mock_thread = AsyncMock()
-        mock_thread.jump_url = "https://discord.com/threads/123/456"
-        mock_channel.create_thread.return_value = mock_thread
-        mock_interaction.channel = mock_channel
-        mock_interaction.response = AsyncMock()
-        mock_interaction.response.send_message = AsyncMock()
-
-        callback = view._make_details_callback()
-        await callback(mock_interaction)
-
-        create_thread_call = mock_channel.create_thread.call_args
-        thread_name = create_thread_call[1]["name"]
-        # Thread name is "Audit: {prompt_key}" truncated to 100 chars
-        # "Audit: " is 7 chars, so we get "Audit: " + 93 A's = 100 chars
-        assert len(thread_name) == 100
-        assert thread_name == f"Audit: {'A' * 93}"


### PR DESCRIPTION
## Related
None

## Summary
Creates audit detail threads upfront when audits are sent, replacing the on-demand Details button with a persistent footer link in the embed. Also changed the Feedback button to use the same grey style as the quick feedback buttons.

## Changes
- Audit threads created immediately when audit embed is sent (no longer on button click)
- Added `[View Full Details](thread_url)` markdown link in embed footer
- Removed Details button (🔍) from AuditView
- Changed Feedback button (💬) from primary (blue) to secondary (grey) style
- Updated `AuditViewBuilder.build_standard_audit` to be async and accept optional `channel` param
- Updated all callers: `auditing_middleware.py`, `audit_mirror.py`, `error_handlers.py`
- Removed 7 outdated callback tests that tested the removed Details button functionality
- Removed `_make_details_callback` method and related callback code

## Impact
- **Performance**: Thread creation moved from button click to initial audit send (user no longer waits for thread creation)
- **Architecture**: Simpler callback flow - no thread creation logic in button handlers
- **Testing**: Removed 7 tests for deleted callback functionality, all remaining tests pass
- **Breaking changes**: Details button removed; any existing interactions with `audit:details:*` custom IDs will no longer work