### PR TITLE
fix: render audit thread link as clickable markdown field

### DIFF
--- a/lattice/discord_client/dream.py
+++ b/lattice/discord_client/dream.py
@@ -667,7 +667,11 @@ class AuditViewBuilder:
         )
 
         if thread_url:
-            embed.set_footer(text=f"[View Full Details]({thread_url})")
+            embed.add_field(
+                name="\u200b",
+                value=f"[View in thread]({thread_url})",
+                inline=False,
+            )
 
         return embed, view, thread_url
 


### PR DESCRIPTION
## Related
fixes bug introduced in #253

## Summary
Fixes broken link rendering in audit embeds. Discord embed footers don't support markdown links, so the link was displayed as literal text. Changed to use a field with zero-width space name to show a clean clickable link.

## Changes
- Changed audit thread link from footer (no markdown support) to field with zero-width space name
- Link now renders as clickable `[View in thread](url)` instead of literal text

## Impact
- **User Experience**: Links in audit embeds are now clickable
- **Breaking changes**: None